### PR TITLE
feat: Add toolkit version support in agent configuration

### DIFF
--- a/app/api/v1/routers/agents.py
+++ b/app/api/v1/routers/agents.py
@@ -25,6 +25,7 @@ async def configure_agents(
     request: Request,
     project_uuid: Annotated[UUID4, Form()],
     definition: Annotated[Json, Form()],
+    toolkit_version: Annotated[str, Form()],
     authorization: Annotated[str, Header()],
 ) -> StreamingResponse:
     """
@@ -90,6 +91,7 @@ async def configure_agents(
                     definition,
                     processed_count,
                     skill_count,
+                    toolkit_version,
                 )
 
                 # Send response for this skill
@@ -106,7 +108,7 @@ async def configure_agents(
 
             # Send progress update for Nexus upload
             nexus_response: CLIResponse = {
-                "message": "Sending agents to Nexus...",
+                "message": "Updating your agents...",
                 "data": {
                     "project_uuid": str(project_uuid),
                     "skill_count": len(skill_mapping),
@@ -204,6 +206,7 @@ async def process_skill(  # noqa: PLR0913
     definition: dict[str, Any],
     processed_count: int,
     total_count: int,
+    toolkit_version: str,
 ) -> tuple[CLIResponse, Any | None]:
     """
     Process a single skill file.
@@ -217,7 +220,7 @@ async def process_skill(  # noqa: PLR0913
         definition: The definition data
         processed_count: The number of skills processed so far
         total_count: The total number of skills to process
-        request_id: The request ID for correlation
+        toolkit_version: The version of the toolkit
 
     Returns:
         Tuple of (response, skill_zip_bytes or None if error)
@@ -249,7 +252,7 @@ async def process_skill(  # noqa: PLR0913
         # Create zip package
         logger.info(f"Creating zip package for skill {skill_slug}")
         skill_zip_bytes = create_skill_zip(
-            folder_zip, key, str(project_uuid), skill_entrypoint_module, skill_entrypoint_class
+            folder_zip, key, str(project_uuid), skill_entrypoint_module, skill_entrypoint_class, toolkit_version
         )
 
         file_size_kb = len(skill_zip_bytes.getvalue()) / 1024

--- a/app/api/v1/routers/agents.py
+++ b/app/api/v1/routers/agents.py
@@ -130,7 +130,7 @@ async def configure_agents(
                 yield send_response(typed_error_response, request_id=request_id)
 
                 response_data = typed_error_response.get("data") or {}
-                error_message = str(response_data.get("error", "Unknown error pushing to Nexus"))
+                error_message = str(response_data.get("error", "Unknown error while pushing agents..."))
                 raise Exception(error_message)
 
             # Final message
@@ -325,7 +325,7 @@ def push_to_nexus(
         response = nexus_client.push_agents(str(project_uuid), definition, skill_mapping)
 
         if response.status_code != status.HTTP_200_OK:
-            raise Exception(f"Failed to push agents to Nexus: {response.status_code} {response.text}")
+            raise Exception(f"Failed to push agents: {response.status_code} {response.text}")
 
         logger.info(f"Successfully pushed agents to Nexus for project {project_uuid}")
 
@@ -334,7 +334,7 @@ def push_to_nexus(
     except Exception as e:
         logger.error(f"Failed to push agents to Nexus: {str(e)}", exc_info=True)
         nexus_error: CLIResponse = {
-            "message": "Failed to push agents to Nexus",
+            "message": "Failed to push agents",
             "data": {
                 "project_uuid": str(project_uuid),
                 "error": str(e),

--- a/app/api/v1/routers/tests/test_agents.py
+++ b/app/api/v1/routers/tests/test_agents.py
@@ -743,9 +743,9 @@ class TestPushToNexus:
     @pytest.mark.parametrize(
         "status_code, status_text, expected_error_fragment",
         [
-            (status.HTTP_400_BAD_REQUEST, "Bad request error", "Failed to push agents to Nexus: 400"),
-            (status.HTTP_401_UNAUTHORIZED, "Unauthorized", "Failed to push agents to Nexus: 401"),
-            (status.HTTP_500_INTERNAL_SERVER_ERROR, "Server error", "Failed to push agents to Nexus: 500"),
+            (status.HTTP_400_BAD_REQUEST, "Bad request error", "Failed to push agents: 400"),
+            (status.HTTP_401_UNAUTHORIZED, "Unauthorized", "Failed to push agents: 401"),
+            (status.HTTP_500_INTERNAL_SERVER_ERROR, "Server error", "Failed to push agents: 500"),
         ],
     )
     def test_non_200_status_codes(self, status_code: int, status_text: str, expected_error_fragment: str) -> None:

--- a/app/services/skill/packager.py
+++ b/app/services/skill/packager.py
@@ -24,7 +24,16 @@ def install_toolkit(package_dir: Path, toolkit_version: str) -> None:
     """
     try:
         process = subprocess.run(
-            ["pip", "install", f"weni-agents-toolkit=={toolkit_version}"],
+            [
+                "pip",
+                "install",
+                "--target",
+                str(package_dir),
+                f"weni-agents-toolkit=={toolkit_version}",
+                "--disable-pip-version-check",
+                "--no-cache-dir",
+                "--isolated",  # Isolated mode
+            ],
             capture_output=True,
             text=True,
             timeout=SUBPROCESS_TIMEOUT_SECONDS,

--- a/app/services/skill/packager.py
+++ b/app/services/skill/packager.py
@@ -117,7 +117,7 @@ def build_lambda_function_file(skill_entrypoint_module: str, skill_entrypoint_cl
     return template_content.format(module=skill_entrypoint_module, class_name=skill_entrypoint_class)
 
 
-def create_skill_zip(  # noqa: PLR0913
+def create_skill_zip(  # noqa: PLR0913, PLR0915
     skill_folder_zip_content: bytes,
     skill_key: str,
     project_uuid: str,

--- a/app/services/skill/packager.py
+++ b/app/services/skill/packager.py
@@ -94,7 +94,7 @@ def build_lambda_function_file(skill_entrypoint_module: str, skill_entrypoint_cl
     return template_content.format(module=skill_entrypoint_module, class_name=skill_entrypoint_class)
 
 
-def create_skill_zip(
+def create_skill_zip(  # noqa: PLR0913
     skill_folder_zip_content: bytes,
     skill_key: str,
     project_uuid: str,

--- a/app/services/skill/packager.py
+++ b/app/services/skill/packager.py
@@ -203,9 +203,12 @@ def create_skill_zip(  # noqa: PLR0913
                     arc_name = file_path.relative_to(temp_path)
 
                     # Determine the path in the zip file
-                    if str(arc_name) == "lambda_function.py" or str(arc_name).startswith("package/"):
+                    if str(arc_name) == "lambda_function.py":
                         # Keep these at the root
                         zip_path = str(arc_name)
+                    elif str(arc_name).startswith("package/"):
+                        # move content out of /package and insert it at root
+                        zip_path = str(arc_name).replace("package/", "", 1)
                     else:
                         # Move other files to skill/ directory
                         zip_path = f"skill/{arc_name}"

--- a/app/services/skill/tests/test_packager.py
+++ b/app/services/skill/tests/test_packager.py
@@ -79,7 +79,7 @@ class TestInstallToolkit:
         call_args = mock_run.call_args[0][0]
         assert "pip" in call_args[0], "Should call pip"
         assert "install" in call_args[1], "Should use install command"
-        assert "weni-agents-toolkit==1.0.0" in call_args[2], "Should specify toolkit version"
+        assert "weni-agents-toolkit==1.0.0" in call_args[4], "Should specify toolkit version"
 
         # Check timer option
         timeout_arg = mock_run.call_args[1].get("timeout")

--- a/app/services/skill/tests/test_packager.py
+++ b/app/services/skill/tests/test_packager.py
@@ -91,7 +91,7 @@ class TestInstallDependencies:
         install_dependencies(temp_dir, requirements_file, "test-skill", "1.0.0")
 
         # Verify subprocess.run was called with correct arguments - now called twice
-        assert mock_run.call_count == 2, "Should call subprocess.run twice"
+        assert mock_run.call_count == 2, "Should call subprocess.run twice"  # noqa: PLR2004
 
         # Check first call (requirements installation)
         first_call_args = mock_run.call_args_list[0][0][0]


### PR DESCRIPTION
- Introduce toolkit_version parameter in configure_agents and process_skill routes
- Update skill packaging utility to include toolkit version during dependency installation
- Modify install_dependencies function to manually install weni-agents-toolkit with specified version
- Update progress message for agent configuration to be more descriptive