### PR TITLE
refactor: Move process_skill function to packager module

### DIFF
--- a/app/api/v1/routers/agents.py
+++ b/app/api/v1/routers/agents.py
@@ -1,5 +1,5 @@
 """
-Skill endpoints for handling file uploads and processing.
+Agents endpoints for handling file uploads and processing.
 """
 
 import logging
@@ -14,7 +14,7 @@ from starlette.datastructures import UploadFile
 
 from app.clients.nexus_client import NexusClient
 from app.core.response import CLIResponse, send_response
-from app.services.skill.packager import create_skill_zip
+from app.services.skill.packager import process_skill
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -195,102 +195,6 @@ async def read_skills_content(skills_folders_zips: dict[str, UploadFile]) -> lis
         List of tuples containing (key, file_content)
     """
     return [(key, await file.read()) for key, file in skills_folders_zips.items()]
-
-
-async def process_skill(  # noqa: PLR0913
-    folder_zip: bytes,
-    key: str,
-    project_uuid: str,
-    agent_slug: str,
-    skill_slug: str,
-    definition: dict[str, Any],
-    processed_count: int,
-    total_count: int,
-    toolkit_version: str,
-) -> tuple[CLIResponse, Any | None]:
-    """
-    Process a single skill file.
-
-    Args:
-        folder_zip: The skill folder zip file content
-        key: The skill key (agent:skill)
-        project_uuid: The UUID of the project
-        agent_slug: The slug of the agent
-        skill_slug: The name of the skill
-        definition: The definition data
-        processed_count: The number of skills processed so far
-        total_count: The total number of skills to process
-        toolkit_version: The version of the toolkit
-
-    Returns:
-        Tuple of (response, skill_zip_bytes or None if error)
-    """
-    # Reduce the progress to be always between 0.2 and 0.9
-    progress = 0.2 + (processed_count / total_count) * 0.7
-    logger.info(f"Processing skill {skill_slug} for agent {agent_slug} ({processed_count}/{total_count})")
-
-    try:
-        # Get skill entrypoint
-        agent_info = next((agent for agent in definition["agents"].values() if agent["slug"] == agent_slug), None)
-
-        if not agent_info:
-            raise ValueError(f"Could not find agent {agent_slug} in definition")
-
-        skill_info = next(
-            (skill for skill in agent_info["skills"] if skill["slug"] == skill_slug),
-            None,
-        )
-
-        if not skill_info:
-            raise ValueError(f"Could not find skill {skill_slug} for agent {agent_slug} in definition")
-
-        skill_entrypoint = skill_info["source"]["entrypoint"]
-        skill_entrypoint_module = skill_entrypoint.split(".")[0]
-        skill_entrypoint_class = skill_entrypoint.split(".")[1]
-        logger.debug(f"Skill entrypoint: {skill_entrypoint_module}.{skill_entrypoint_class}")
-
-        # Create zip package
-        logger.info(f"Creating zip package for skill {skill_slug}")
-        skill_zip_bytes = create_skill_zip(
-            folder_zip, key, str(project_uuid), skill_entrypoint_module, skill_entrypoint_class, toolkit_version
-        )
-
-        file_size_kb = len(skill_zip_bytes.getvalue()) / 1024
-        logger.debug(f"Successfully created zip for {key}, size: {file_size_kb:.2f} KB")
-
-        # Prepare success response
-        response: CLIResponse = {
-            "message": f"Skill {skill_slug} processed successfully ({processed_count}/{total_count})",
-            "data": {
-                "skill_name": skill_slug,
-                "agent_name": agent_slug,
-                "size_kb": round(file_size_kb, 2),
-                "processed": processed_count,
-                "total": total_count,
-            },
-            "success": True,
-            "code": "SKILL_PROCESSED",
-            "progress": progress,
-        }
-
-        return response, skill_zip_bytes
-
-    except Exception as e:
-        logger.error(f"Failed to process skill {key}: {str(e)}")
-        error_response: CLIResponse = {
-            "message": f"Failed to process skill {skill_slug}",
-            "data": {
-                "skill_name": skill_slug,
-                "agent_name": agent_slug,
-                "error": str(e),
-                "processed": processed_count,
-                "total": total_count,
-            },
-            "success": False,
-            "code": "SKILL_PROCESSING_ERROR",
-            "progress": progress,
-        }
-        return error_response, None
 
 
 def push_to_nexus(

--- a/app/services/skill/tests/test_packager.py
+++ b/app/services/skill/tests/test_packager.py
@@ -2,6 +2,7 @@
 Tests for the skill package packager.
 """
 
+import io
 import os
 import subprocess
 import zipfile
@@ -9,6 +10,8 @@ from collections.abc import Generator
 from io import BytesIO
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
+from typing import Any, ClassVar
+from uuid import uuid4
 
 import pytest
 from pytest_mock import MockerFixture
@@ -20,6 +23,13 @@ from app.services.skill.packager import (
     install_dependencies,
     install_toolkit,
 )
+
+# Common test constants
+TEST_CONTENT = b"test content"
+TEST_AGENT = "test-agent"
+TEST_SKILL = "test-skill"
+TEST_SKILL_KEY = f"{TEST_AGENT}:{TEST_SKILL}"
+TEST_TOKEN = "Bearer test-token"
 
 
 @pytest.fixture
@@ -383,3 +393,131 @@ class TestCreateSkillZip:
 
         # Verify cleanup was attempted (now includes ignore_errors=True)
         rmtree_mock.assert_called_once_with(temp_dir_path, ignore_errors=True), "Should clean up temp directory"
+
+
+class TestProcessSkill:
+    """Tests for process_skill function."""
+
+    # Common test data
+    folder_zip: ClassVar[bytes] = b"test zip content"
+    key: ClassVar[str] = TEST_SKILL_KEY
+    project_uuid: ClassVar[str] = str(uuid4())
+    agent_name: ClassVar[str] = TEST_AGENT
+    skill_name: ClassVar[str] = TEST_SKILL
+    skill_definition: ClassVar[dict[str, Any]] = {
+        "agents": {
+            TEST_AGENT: {
+                "slug": TEST_AGENT,
+                "skills": [
+                    {
+                        "slug": TEST_SKILL,
+                        "source": {"entrypoint": "main.TestSkill"},
+                    }
+                ],
+            }
+        }
+    }
+    processed_count: ClassVar[int] = 1
+    total_count: ClassVar[int] = 2
+    expected_progress: ClassVar[float] = 0.55  # 1/2 * 0.7 + 0.2
+    toolkit_version: ClassVar[str] = "1.0.0"  # Add default toolkit version
+
+    def test_success(self) -> None:
+        """Test successful processing of a skill."""
+        import asyncio
+
+        from app.services.skill.packager import process_skill
+
+        with pytest.MonkeyPatch().context() as mp:
+            mp.setattr(
+                "app.services.skill.packager.create_skill_zip", lambda *args, **kwargs: io.BytesIO(b"packaged content")
+            )
+
+            response, skill_zip = asyncio.run(
+                process_skill(
+                    self.folder_zip,
+                    self.key,
+                    self.project_uuid,
+                    self.agent_name,
+                    self.skill_name,
+                    self.skill_definition,
+                    self.processed_count,
+                    self.total_count,
+                    self.toolkit_version,  # Add toolkit version parameter
+                )
+            )
+
+        assert response["success"] is True, "Should report success"
+        assert skill_zip is not None, "Should return skill zip"
+        assert response["data"] is not None, "Response should include data"
+        assert response["data"]["skill_name"] == self.skill_name, "Should include skill name"
+        assert response["progress"] == self.expected_progress, f"Progress should be {self.expected_progress}"
+
+    def test_missing_agent_in_definition(self) -> None:
+        """Test handling of missing agent in definition."""
+        import asyncio
+
+        from app.services.skill.packager import process_skill
+
+        # Use a non-existent agent name
+        missing_agent = "non-existent-agent"
+
+        response, skill_zip = asyncio.run(
+            process_skill(
+                self.folder_zip,
+                f"{missing_agent}:{self.skill_name}",
+                self.project_uuid,
+                missing_agent,  # Use the missing agent name
+                self.skill_name,
+                self.skill_definition,  # Definition only contains TEST_AGENT
+                self.processed_count,
+                self.total_count,
+                self.toolkit_version,  # Add toolkit version parameter
+            )
+        )
+
+        assert response["success"] is False, "Should report failure"
+        assert skill_zip is None, "Should not return skill zip"
+        assert response["data"] is not None, "Response should include data"
+        assert "Could not find agent" in response["data"]["error"], "Error should mention missing agent"
+        assert missing_agent in response["data"]["error"], "Error should include the missing agent name"
+
+    @pytest.mark.parametrize(
+        "scenario, key, skill_name, expected_error",
+        [
+            ("missing_skill", "test-agent:missing-skill", "missing-skill", "Could not find skill"),
+            ("exception", TEST_SKILL_KEY, TEST_SKILL, "Zip creation error"),
+        ],
+    )
+    def test_error_scenarios(self, scenario: str, key: str, skill_name: str, expected_error: str) -> None:
+        """Test various error scenarios in skill processing."""
+        import asyncio
+
+        from app.api.v1.routers.agents import process_skill
+
+        with pytest.MonkeyPatch().context() as mp:
+            if scenario == "exception":
+                # Cause an exception
+                mp.setattr(
+                    "app.services.skill.packager.create_skill_zip",
+                    lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("Zip creation error")),
+                )
+
+            response, skill_zip = asyncio.run(
+                process_skill(
+                    self.folder_zip,
+                    key,
+                    self.project_uuid,
+                    self.agent_name,
+                    skill_name,
+                    self.skill_definition,
+                    self.processed_count,
+                    self.total_count,
+                    self.toolkit_version,  # Add toolkit version parameter
+                )
+            )
+
+        assert response["success"] is False, "Should report failure"
+        assert response["data"] is not None, "Response should include data"
+        assert expected_error in response["data"]["error"], f"Should include '{expected_error}' in error message"
+        assert skill_zip is None, "Should not return skill zip"


### PR DESCRIPTION
- Relocate process_skill function from agents.py to packager.py
- Update import statements and type hints
- Maintain existing function logic and error handling
- Improve code organization by keeping skill processing logic in dedicated module