### PR TITLE
feat: Add runs router for skill test execution

### DIFF
--- a/app/api/v1/models/requests.py
+++ b/app/api/v1/models/requests.py
@@ -15,3 +15,5 @@ class RunSkillRequestModel(BaseRequestModel):
     test_definition: Json
     skill_name: str
     agent_name: str
+    skill_credentials: Json
+    skill_globals: Json

--- a/app/api/v1/routers/runs.py
+++ b/app/api/v1/routers/runs.py
@@ -158,6 +158,10 @@ async def run_skill_test(  # noqa: PLR0915
                     "action_group": lambda_function.function_name,
                     "function": lambda_function.function_name,
                     "parameters": test_data.get("parameters", []),
+                    "sessionAttributes": {
+                        "credentials": test_data.get("credentials", data.skill_credentials),
+                        "globals": test_data.get("globals", data.skill_globals),
+                    },
                 }
 
                 # Invoke lambda function

--- a/app/api/v1/routers/runs.py
+++ b/app/api/v1/routers/runs.py
@@ -154,11 +154,15 @@ async def run_skill_test(  # noqa: PLR0915
                 }
                 yield send_response(response, request_id=request_id)
 
+                parameters = []
+                for key, value in test_data.get("parameters", {}).items():
+                    parameters.append({"name": key, "value": value})
+
                 test_event = {
                     "agent_name": data.agent_name,
                     "action_group": lambda_function.function_name,
                     "function": lambda_function.function_name,
-                    "parameters": test_data.get("parameters", []),
+                    "parameters": parameters,
                     "sessionAttributes": {
                         "credentials": json.dumps(test_data.get("credentials", data.skill_credentials)),
                         "globals": json.dumps(test_data.get("globals", data.skill_globals)),

--- a/app/api/v1/routers/runs.py
+++ b/app/api/v1/routers/runs.py
@@ -1,0 +1,219 @@
+"""
+Skill runs endpoints for handling file uploads and processing.
+"""
+
+import logging
+from collections.abc import AsyncIterator
+from typing import Annotated
+from uuid import uuid4
+
+from fastapi import APIRouter, Form, Header, HTTPException, Request
+from fastapi.responses import StreamingResponse
+from starlette.datastructures import UploadFile
+
+from app.api.v1.models.requests import RunSkillRequestModel
+from app.clients.aws import AWSLambdaClient, AWSLogsClient
+from app.core.response import CLIResponse, send_response
+from app.services.skill.packager import process_skill
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+@router.post("")
+async def run_skill_test(  # noqa: PLR0915
+    request: Request,
+    data: Annotated[RunSkillRequestModel, Form()],
+    authorization: Annotated[str, Header()],
+) -> StreamingResponse:
+    request_id = str(uuid4())
+    logger.info(f"Processing test run for project {data.project_uuid} - request_id: {request_id}")
+    logger.debug(f"Agent definition: {data.definition}")
+
+    # Access the form data with files
+    form = await request.form()
+
+    # Extract and process skill files
+    skill_folder_zip = form.get("skill")
+
+    if not skill_folder_zip or not isinstance(skill_folder_zip, UploadFile):
+        raise HTTPException(status_code=400, detail="Skill folder zip is required")
+
+    folder_zip = await skill_folder_zip.read()
+
+    logger.info(f"Found skill folder to process for project {data.project_uuid}")
+    logger.debug(f"Skill folder zip: {skill_folder_zip}")
+
+    function_name = str(uuid4())
+    lambda_client = AWSLambdaClient()
+
+    async def response_stream() -> AsyncIterator[bytes]:
+        try:
+            initial_data: CLIResponse = {
+                "message": "Processing test run...",
+                "data": {
+                    "project_uuid": str(data.project_uuid),
+                },
+                "success": True,
+                "code": "PROCESSING_STARTED",
+            }
+            yield send_response(initial_data, request_id=request_id)
+            logger.info(f"Starting test run for skill {data.skill_name} by {data.agent_name}")
+
+            # Get skill entrypoint
+            agent_info = next(
+                (agent for agent in data.definition["agents"].values() if agent.get("name") == data.agent_name),
+                None,
+            )
+
+            if not agent_info:
+                raise ValueError(f"Could not find agent {data.agent_name} in definition")
+
+            logger.debug(f"Agent info: {agent_info}")
+
+            skill_info = next(
+                (skill for skill in agent_info["skills"] if skill["name"] == data.skill_name),
+                None,
+            )
+
+            if not skill_info:
+                raise ValueError(f"Could not find skill {data.skill_name} for agent {data.agent_name} in definition")
+
+            logger.debug(f"Skill info: {skill_info}")
+
+            # Process the skill folder zip
+            response, skill_zip_bytes = await process_skill(
+                folder_zip,
+                f"{agent_info.get('slug')}:{skill_info.get('slug')}",
+                str(data.project_uuid),
+                agent_info.get("slug"),
+                skill_info.get("slug"),
+                data.definition,
+                1,
+                1,
+                data.toolkit_version,
+            )
+
+            # Send response for this skill
+            yield send_response(response, request_id=request_id)
+
+            if not skill_zip_bytes:
+                raise ValueError("Failed to process skill, aborting test run")
+
+            response = {
+                "message": "Creating lambda function",
+                "data": {
+                    "project_uuid": str(data.project_uuid),
+                    "function_name": function_name,
+                },
+                "success": True,
+                "code": "LAMBDA_FUNCTION_CREATING",
+            }
+            yield send_response(response, request_id=request_id)
+
+            # Create lambda function
+            lambda_function = lambda_client.create_function(
+                function_name=function_name,
+                handler="lambda_function.lambda_handler",
+                code=skill_zip_bytes,
+                description=f"CLI run for skill {data.skill_name} by {data.agent_name}. Project: {data.project_uuid}",
+            )
+
+            if not lambda_function.function_arn or not lambda_function.function_name:
+                raise ValueError("Failed to create lambda function")
+
+            if not await lambda_client.wait_for_function_active(lambda_function.function_arn):
+                raise ValueError("Lambda function did not became active")
+
+            logger.info(f"Lambda function {lambda_function.function_arn} active, invoking...")
+
+            response = {
+                "message": "Running test cases",
+                "data": {
+                    "project_uuid": str(data.project_uuid),
+                    "function_name": function_name,
+                },
+                "success": True,
+                "code": "STARTING_TEST_CASES",
+            }
+            yield send_response(response, request_id=request_id)
+
+            for test_case, test_data in data.test_definition.get("tests", {}).items():
+                logger.info(f"Running test case {test_case} for skill {data.skill_name} by {data.agent_name}")
+
+                response = {
+                    "message": f"Running test case {test_case}",
+                    "data": {
+                        "project_uuid": str(data.project_uuid),
+                        "function_name": function_name,
+                        "test_case": test_case,
+                    },
+                    "success": True,
+                    "code": "TEST_CASE_RUNNING",
+                }
+                yield send_response(response, request_id=request_id)
+
+                test_event = {
+                    "agent_name": data.agent_name,
+                    "action_group": lambda_function.function_name,
+                    "function": lambda_function.function_name,
+                    "parameters": test_data.get("parameters", []),
+                }
+
+                # Invoke lambda function
+                invoke_result, invoke_start_time, invoke_end_time = lambda_client.invoke_function(
+                    lambda_function.function_arn, test_event
+                )
+
+                # Get lambda function logs
+                logs_client = AWSLogsClient()
+                logs = await logs_client.get_function_logs(
+                    function_name=lambda_function.function_name,
+                    start_time=invoke_start_time,
+                    end_time=invoke_end_time,
+                )
+
+                test_response: CLIResponse = {
+                    "message": "Test case completed",
+                    "data": {
+                        "test_case": test_case,
+                        "logs": logs,
+                        "duration": invoke_end_time - invoke_start_time,
+                        "test_status_code": invoke_result.get("status_code"),
+                        "test_response": invoke_result.get("response"),
+                    },
+                    "success": True,
+                    "code": "TEST_CASE_COMPLETED",
+                }
+
+                yield send_response(test_response, request_id=request_id)
+
+            response = {
+                "message": "Test run completed",
+                "data": {
+                    "project_uuid": str(data.project_uuid),
+                },
+                "success": True,
+                "code": "TEST_RUN_COMPLETED",
+            }
+            yield send_response(response, request_id=request_id)
+
+        except Exception as e:
+            logger.error(
+                f"Error processing test run for project {data.project_uuid}: {str(e)} - request_id: {request_id}"
+            )
+            error_data: CLIResponse = {
+                "message": "Error processing test run",
+                "data": {
+                    "project_uuid": str(data.project_uuid),
+                    "error": str(e),
+                },
+                "success": False,
+                "code": "PROCESSING_ERROR",
+            }
+            yield send_response(error_data, request_id=request_id)
+        finally:
+            # Delete lambda function
+            lambda_client.delete_function(function_name=function_name)
+
+    return StreamingResponse(response_stream(), media_type="application/x-ndjson")

--- a/app/api/v1/routers/runs.py
+++ b/app/api/v1/routers/runs.py
@@ -2,6 +2,7 @@
 Skill runs endpoints for handling file uploads and processing.
 """
 
+import json
 import logging
 from collections.abc import AsyncIterator
 from typing import Annotated
@@ -159,8 +160,8 @@ async def run_skill_test(  # noqa: PLR0915
                     "function": lambda_function.function_name,
                     "parameters": test_data.get("parameters", []),
                     "sessionAttributes": {
-                        "credentials": test_data.get("credentials", data.skill_credentials),
-                        "globals": test_data.get("globals", data.skill_globals),
+                        "credentials": json.dumps(test_data.get("credentials", data.skill_credentials)),
+                        "globals": json.dumps(test_data.get("globals", data.skill_globals)),
                     },
                 }
 

--- a/app/api/v1/routers/tests/test_runs.py
+++ b/app/api/v1/routers/tests/test_runs.py
@@ -1,0 +1,640 @@
+"""Tests for skill runs endpoint."""
+
+import io
+import json
+from collections.abc import Callable
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+from pytest_mock import MockerFixture
+
+from app.core.config import settings
+from app.main import app
+from app.tests.utils import AsyncMock
+
+# Common test constants
+TEST_CONTENT = b"test content"
+TEST_AGENT_NAME = "test-agent"
+TEST_SKILL_NAME = "test-skill"
+TEST_TOKEN = "Bearer test-token"
+TEST_FUNCTION_NAME = "test-function-name"
+TEST_FUNCTION_ARN = "arn:aws:lambda:us-east-1:123456789012:function:test-function-name"
+TEST_START_TIME = 1000.0
+TEST_END_TIME = 1030.0  # 30 seconds after start
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    """Return a FastAPI test client."""
+    return TestClient(app)
+
+
+@pytest.fixture(scope="module")
+def api_path() -> str:
+    """Return the API path for runs."""
+    return f"{settings.API_PREFIX}/v1/runs"
+
+
+@pytest.fixture
+def project_uuid() -> UUID:
+    """Return a test project UUID."""
+    return uuid4()
+
+
+@pytest.fixture(scope="module")
+def auth_header() -> dict[str, str]:
+    """Return an authorization header for tests."""
+    return {"Authorization": TEST_TOKEN}
+
+
+@pytest.fixture
+def run_skill_request_data() -> dict[str, Any]:
+    """Return test data for run_skill_test endpoint."""
+    agent_definition = {
+        "name": TEST_AGENT_NAME,
+        "slug": "test-agent-slug",
+        "skills": [
+            {
+                "name": TEST_SKILL_NAME,
+                "slug": "test-skill-slug",
+            }
+        ],
+    }
+
+    test_definition = {
+        "tests": {
+            "test_case_1": {"parameters": {"input": "Hello world"}},
+            "test_case_2": {"parameters": {"input": "Another test"}},
+        }
+    }
+
+    return {
+        "project_uuid": str(uuid4()),
+        "definition": json.dumps({"agents": {"test-agent-id": agent_definition}}),
+        "test_definition": json.dumps(test_definition),
+        "skill_name": TEST_SKILL_NAME,
+        "agent_name": TEST_AGENT_NAME,
+        "toolkit_version": "1.0.0",
+    }
+
+
+@pytest.fixture
+def test_log_events() -> list[dict[str, Any]]:
+    """Return test log events."""
+    return [
+        {"timestamp": 1001, "message": "START RequestId: test-request-id", "logStreamName": "stream1"},
+        {"timestamp": 1002, "message": "Processing request", "logStreamName": "stream1"},
+        {"timestamp": 1003, "message": "END RequestId: test-request-id", "logStreamName": "stream1"},
+    ]
+
+
+@pytest.fixture
+def post_run_request_factory(
+    client: TestClient, api_path: str, auth_header: dict[str, str], run_skill_request_data: dict[str, Any]
+) -> Callable[[], Any]:
+    """Return a factory function for making POST requests to the runs endpoint."""
+
+    def make_post_request() -> Any:
+        # Create files dictionary with the skill file
+        files = {
+            "skill": ("test_skill.zip", io.BytesIO(TEST_CONTENT), "application/zip"),
+        }
+
+        # Merge the data and files for the multipart request
+        data = {**run_skill_request_data}
+
+        return client.post(api_path, data=data, files=files, headers=auth_header)
+
+    return make_post_request
+
+
+@pytest.fixture
+def custom_post_run_request_factory(
+    client: TestClient,
+    api_path: str,
+    auth_header: dict[str, str],
+) -> Callable[[dict[str, Any], dict[str, Any], dict[str, str] | None], Any]:
+    """Return a factory function for making custom POST requests to the runs endpoint."""
+
+    def make_custom_post_request(
+        data_fields: dict[str, Any],
+        files_fields: dict[str, Any],
+        headers: dict[str, str] | None = None,
+    ) -> Any:
+        # Use default auth_header if no headers provided
+        request_headers = headers if headers is not None else auth_header
+
+        return client.post(api_path, data=data_fields, files=files_fields, headers=request_headers)
+
+    return make_custom_post_request
+
+
+def parse_streaming_response(response: Any) -> list[dict[str, Any]]:
+    """Parse a streaming response into a list of JSON objects."""
+    result = []
+    for line in response.iter_lines():
+        if line:
+            try:
+                result.append(json.loads(line))
+            except json.JSONDecodeError:
+                # Skip lines that aren't valid JSON
+                pass
+    return result
+
+
+class TestRunSkillEndpoint:
+    """Tests for the run_skill_test endpoint."""
+
+    @pytest.fixture
+    def mock_success_dependencies(self, mocker: MockerFixture) -> None:
+        """Mock dependencies for successful test run."""
+        # Mock process_skill
+        mock_process_result = {
+            "message": "Skill processed successfully",
+            "data": {
+                "skill_name": TEST_SKILL_NAME,
+            },
+            "success": True,
+            "code": "SKILL_PROCESSED",
+        }
+
+        mocker.patch(
+            "app.api.v1.routers.runs.process_skill",
+            new=AsyncMock(return_value=(mock_process_result, io.BytesIO(TEST_CONTENT))),
+        )
+
+        # Mock AWSLambdaClient
+        # Create a proper async mock for wait_for_function_active
+        wait_for_function_active_mock = AsyncMock(return_value=True)
+
+        mock_create_function_result = mocker.Mock()
+        mock_create_function_result.function_arn = TEST_FUNCTION_ARN
+        mock_create_function_result.function_name = TEST_FUNCTION_NAME
+
+        mock_lambda_client = mocker.Mock()
+        mock_lambda_client.create_function.return_value = mock_create_function_result
+        mock_lambda_client.invoke_function.return_value = (
+            {"status_code": 200, "response": {"result": "Test executed successfully"}},
+            TEST_START_TIME,
+            TEST_END_TIME,
+        )
+        mock_lambda_client.wait_for_function_active = wait_for_function_active_mock
+
+        mocker.patch("app.api.v1.routers.runs.AWSLambdaClient", return_value=mock_lambda_client)
+
+        # Mock AWSLogsClient
+        # Create a properly configured AWSLogsClient mock with async method
+        mock_logs = [
+            {"timestamp": 1001, "message": "START RequestId: test-request-id"},
+            {"timestamp": 1002, "message": "Processing request"},
+            {"timestamp": 1003, "message": "END RequestId: test-request-id"},
+        ]
+
+        mock_logs_client = mocker.Mock()
+        mock_logs_client.get_function_logs = AsyncMock(return_value=mock_logs)
+
+        mocker.patch("app.api.v1.routers.runs.AWSLogsClient", return_value=mock_logs_client)
+
+    def test_run_skill_success(
+        self, post_run_request_factory: Callable[[], Any], mock_success_dependencies: None
+    ) -> None:
+        """Test successful run_skill_test endpoint."""
+        # Minimum expected response items
+        min_expected_responses = 5  # initial, skill processed, lambda creating, test case, completion
+
+        # Execute
+        response = post_run_request_factory()
+
+        # Assert
+        assert response.status_code == status.HTTP_200_OK
+
+        # Parse the streaming response
+        response_data = parse_streaming_response(response)
+
+        # Check for expected response objects
+        assert (
+            len(response_data) >= min_expected_responses
+        )  # At least initial response, skill processed, lambda creating, test case, completion
+
+        # Check initial response
+        assert response_data[0]["code"] == "PROCESSING_STARTED"
+        assert response_data[0]["success"] is True
+
+        # Check that test cases were run
+        test_case_completed = False
+        for resp in response_data:
+            if resp.get("code") == "TEST_CASE_COMPLETED":
+                test_case_completed = True
+                assert "test_response" in resp["data"]
+                assert "logs" in resp["data"]
+                assert "duration" in resp["data"]
+
+        assert test_case_completed, "No test case completion message found"
+
+        # Check completion message
+        final_message = response_data[-1]
+        assert final_message["code"] == "TEST_RUN_COMPLETED"
+        assert final_message["success"] is True
+
+    @pytest.mark.parametrize(
+        "test_id, data_fields, files_fields, headers, expected_status, expected_error_code",
+        [
+            (
+                "missing_skill_file",
+                {
+                    "project_uuid": str(uuid4()),
+                    "definition": json.dumps({"agents": {}}),
+                    "test_definition": json.dumps({"tests": {}}),
+                    "skill_name": TEST_SKILL_NAME,
+                    "agent_name": TEST_AGENT_NAME,
+                    "toolkit_version": "1.0.0",
+                },
+                {},  # No skill file
+                None,  # Use default auth header
+                status.HTTP_400_BAD_REQUEST,
+                None,  # No streaming response for 400
+            ),
+            (
+                "missing_authorization",
+                {
+                    "project_uuid": str(uuid4()),
+                    "definition": json.dumps({"agents": {}}),
+                    "test_definition": json.dumps({"tests": {}}),
+                    "skill_name": TEST_SKILL_NAME,
+                    "agent_name": TEST_AGENT_NAME,
+                    "toolkit_version": "1.0.0",
+                },
+                {
+                    "skill": ("test_skill.zip", io.BytesIO(TEST_CONTENT), "application/zip"),
+                },
+                {},  # Empty headers - no auth
+                status.HTTP_422_UNPROCESSABLE_ENTITY,
+                None,  # No streaming response for 422
+            ),
+        ],
+    )
+    def test_validation_errors(  # noqa: PLR0913
+        self,
+        custom_post_run_request_factory: Callable[[dict[str, Any], dict[str, Any], dict[str, str] | None], Any],
+        test_id: str,
+        data_fields: dict[str, Any],
+        files_fields: dict[str, Any],
+        headers: dict[str, str] | None,
+        expected_status: int,
+        expected_error_code: str | None,
+    ) -> None:
+        """Test validation errors for run_skill_test endpoint."""
+        # Execute
+        response = custom_post_run_request_factory(data_fields, files_fields, headers)
+
+        # Assert
+        assert response.status_code == expected_status
+
+        # For error responses with streaming, check the error code
+        if expected_error_code:
+            response_data = parse_streaming_response(response)
+            assert len(response_data) > 0
+            assert response_data[-1]["code"] == expected_error_code
+            assert response_data[-1]["success"] is False
+
+    def test_process_skill_error(self, post_run_request_factory: Callable[[], Any], mocker: MockerFixture) -> None:
+        """Test error during skill processing."""
+        # Setup
+        error_message = "Error processing skill"
+        mocker.patch("app.api.v1.routers.runs.process_skill", new=AsyncMock(side_effect=ValueError(error_message)))
+
+        # Mock lambda client and its methods to avoid any real AWS calls
+        mock_lambda_client = mocker.Mock()
+        # Make sure delete_function is properly mocked
+        mock_lambda_client.delete_function.return_value = None
+
+        mocker.patch("app.api.v1.routers.runs.AWSLambdaClient", return_value=mock_lambda_client)
+
+        # Mock the logs client as well
+        mock_logs_client = mocker.Mock()
+        mock_logs_client.get_function_logs = AsyncMock(return_value=[])
+
+        mocker.patch("app.api.v1.routers.runs.AWSLogsClient", return_value=mock_logs_client)
+
+        # Execute
+        response = post_run_request_factory()
+
+        # Assert
+        assert response.status_code == status.HTTP_200_OK
+
+        # Parse the streaming response
+        response_data = parse_streaming_response(response)
+
+        # Check for error response
+        final_message = response_data[-1]
+        assert final_message["code"] == "PROCESSING_ERROR"
+        assert final_message["success"] is False
+        assert error_message in final_message["data"]["error"]
+
+    def test_lambda_function_creation_failure(
+        self, post_run_request_factory: Callable[[], Any], mocker: MockerFixture
+    ) -> None:
+        """Test failure in lambda function creation."""
+        # Mock process_skill to succeed
+        mock_process_result = {
+            "message": "Skill processed successfully",
+            "data": {
+                "skill_name": TEST_SKILL_NAME,
+            },
+            "success": True,
+            "code": "SKILL_PROCESSED",
+        }
+
+        mocker.patch(
+            "app.api.v1.routers.runs.process_skill",
+            new=AsyncMock(return_value=(mock_process_result, io.BytesIO(TEST_CONTENT))),
+        )
+
+        # Mock lambda client to fail on create_function
+        mock_lambda_client = mocker.Mock()
+        mock_lambda_client.create_function.return_value = mocker.Mock(function_arn=None, function_name=None)
+        mocker.patch("app.api.v1.routers.runs.AWSLambdaClient", return_value=mock_lambda_client)
+
+        # Execute
+        response = post_run_request_factory()
+
+        # Assert
+        assert response.status_code == status.HTTP_200_OK
+
+        # Parse the streaming response
+        response_data = parse_streaming_response(response)
+
+        # Check for error response
+        final_message = response_data[-1]
+        assert final_message["code"] == "PROCESSING_ERROR"
+        assert final_message["success"] is False
+        assert "Failed to create lambda function" in final_message["data"]["error"]
+
+    def test_lambda_function_activation_failure(
+        self, post_run_request_factory: Callable[[], Any], mocker: MockerFixture
+    ) -> None:
+        """Test failure in lambda function activation."""
+        # Mock process_skill to succeed
+        mock_process_result = {
+            "message": "Skill processed successfully",
+            "data": {
+                "skill_name": TEST_SKILL_NAME,
+            },
+            "success": True,
+            "code": "SKILL_PROCESSED",
+        }
+
+        mocker.patch(
+            "app.api.v1.routers.runs.process_skill",
+            new=AsyncMock(return_value=(mock_process_result, io.BytesIO(TEST_CONTENT))),
+        )
+
+        # Mock AWSLambdaClient to succeed on create but fail on activation
+        mock_create_function_result = mocker.Mock()
+        mock_create_function_result.function_arn = TEST_FUNCTION_ARN
+        mock_create_function_result.function_name = TEST_FUNCTION_NAME
+
+        mock_lambda_client = mocker.Mock()
+        mock_lambda_client.create_function.return_value = mock_create_function_result
+        # Use AsyncMock for wait_for_function_active
+        mock_lambda_client.wait_for_function_active = AsyncMock(return_value=False)
+
+        mocker.patch("app.api.v1.routers.runs.AWSLambdaClient", return_value=mock_lambda_client)
+
+        # Execute
+        response = post_run_request_factory()
+
+        # Assert
+        assert response.status_code == status.HTTP_200_OK
+
+        # Parse the streaming response
+        response_data = parse_streaming_response(response)
+
+        # Check for error response
+        final_message = response_data[-1]
+        assert final_message["code"] == "PROCESSING_ERROR"
+        assert final_message["success"] is False
+        assert "Lambda function did not became active" in final_message["data"]["error"]
+
+    def test_lambda_function_invocation_error(
+        self, post_run_request_factory: Callable[[], Any], mocker: MockerFixture
+    ) -> None:
+        """Test error during lambda function invocation."""
+        # Mock process_skill to succeed
+        mock_process_result = {
+            "message": "Skill processed successfully",
+            "data": {
+                "skill_name": TEST_SKILL_NAME,
+            },
+            "success": True,
+            "code": "SKILL_PROCESSED",
+        }
+
+        mocker.patch(
+            "app.api.v1.routers.runs.process_skill",
+            new=AsyncMock(return_value=(mock_process_result, io.BytesIO(TEST_CONTENT))),
+        )
+
+        # Mock AWSLambdaClient to succeed on create and activation
+        mock_create_function_result = mocker.Mock()
+        mock_create_function_result.function_arn = TEST_FUNCTION_ARN
+        mock_create_function_result.function_name = TEST_FUNCTION_NAME
+
+        mock_lambda_client = mocker.Mock()
+        mock_lambda_client.create_function.return_value = mock_create_function_result
+        # Mock invoke_function to raise an exception
+        mock_lambda_client.invoke_function.side_effect = Exception("Invoke function error")
+        # Need to properly mock the wait_for_function_active method as async
+        mock_lambda_client.wait_for_function_active = AsyncMock(return_value=True)
+
+        mocker.patch("app.api.v1.routers.runs.AWSLambdaClient", return_value=mock_lambda_client)
+
+        # Create a properly configured AWSLogsClient mock with async method
+        mock_logs_client = mocker.Mock()
+        mock_logs_client.get_function_logs = AsyncMock(return_value=[])
+
+        mocker.patch("app.api.v1.routers.runs.AWSLogsClient", return_value=mock_logs_client)
+
+        # Execute
+        response = post_run_request_factory()
+
+        # Assert
+        assert response.status_code == status.HTTP_200_OK
+
+        # Parse the streaming response
+        response_data = parse_streaming_response(response)
+
+        # Check for error response
+        final_message = response_data[-1]
+        assert final_message["code"] == "PROCESSING_ERROR"
+        assert final_message["success"] is False
+        assert "Invoke function error" in final_message["data"]["error"]
+
+    def test_clean_up_on_error(self, post_run_request_factory: Callable[[], Any], mocker: MockerFixture) -> None:
+        """Test that lambda function is deleted even when errors occur."""
+        # Mock process_skill to fail
+        mocker.patch(
+            "app.api.v1.routers.runs.process_skill", new=AsyncMock(side_effect=ValueError("Process skill error"))
+        )
+
+        # Mock lambda client
+        mock_lambda_client = mocker.Mock()
+        mock_lambda_client.delete_function.return_value = None
+
+        mocker.patch("app.api.v1.routers.runs.AWSLambdaClient", return_value=mock_lambda_client)
+
+        # Mock logs client
+        mock_logs_client = mocker.Mock()
+        mock_logs_client.get_function_logs = AsyncMock(return_value=[])
+
+        mocker.patch("app.api.v1.routers.runs.AWSLogsClient", return_value=mock_logs_client)
+
+        # Execute
+        post_run_request_factory()
+
+        # Assert
+        # Check that delete_function was called even though the process failed
+        assert mock_lambda_client.delete_function.call_count == 1
+        assert mock_lambda_client.delete_function.call_args[1]["function_name"] is not None
+
+    def test_agent_not_found_in_definition(
+        self,
+        post_run_request_factory: Callable[[], Any],
+        mocker: MockerFixture,
+        run_skill_request_data: dict[str, Any],
+    ) -> None:
+        """Test error when agent is not found in the definition."""
+        # Modify the definition to have an empty agents dict
+        modified_data = run_skill_request_data.copy()
+        modified_data["definition"] = json.dumps({"agents": {}})
+
+        # Create mock for all necessary components
+        mock_lambda_client = mocker.Mock()
+        mock_lambda_client.delete_function.return_value = None
+        mocker.patch("app.api.v1.routers.runs.AWSLambdaClient", return_value=mock_lambda_client)
+
+        mock_logs_client = mocker.Mock()
+        mock_logs_client.get_function_logs = AsyncMock(return_value=[])
+        mocker.patch("app.api.v1.routers.runs.AWSLogsClient", return_value=mock_logs_client)
+
+        # Create custom request with the modified data
+        client = TestClient(app)
+        api_path = f"{settings.API_PREFIX}/v1/runs"
+        files = {
+            "skill": ("test_skill.zip", io.BytesIO(TEST_CONTENT), "application/zip"),
+        }
+
+        # Execute
+        response = client.post(api_path, data=modified_data, files=files, headers={"Authorization": TEST_TOKEN})
+
+        # Assert
+        assert response.status_code == status.HTTP_200_OK
+
+        # Parse the streaming response
+        response_data = parse_streaming_response(response)
+
+        # Check for error response
+        final_message = response_data[-1]
+        assert final_message["code"] == "PROCESSING_ERROR"
+        assert final_message["success"] is False
+        assert f"Could not find agent {TEST_AGENT_NAME} in definition" in final_message["data"]["error"]
+
+    def test_skill_not_found_for_agent(
+        self,
+        post_run_request_factory: Callable[[], Any],
+        mocker: MockerFixture,
+        run_skill_request_data: dict[str, Any],
+    ) -> None:
+        """Test error when skill is not found for the agent."""
+        # Modify the definition to have an agent with no skills
+        agent_definition = {
+            "name": TEST_AGENT_NAME,
+            "slug": "test-agent-slug",
+            "skills": [],  # Empty skills list
+        }
+
+        modified_data = run_skill_request_data.copy()
+        modified_data["definition"] = json.dumps({"agents": {"test-agent-id": agent_definition}})
+
+        # Create mock for all necessary components
+        mock_lambda_client = mocker.Mock()
+        mock_lambda_client.delete_function.return_value = None
+        mocker.patch("app.api.v1.routers.runs.AWSLambdaClient", return_value=mock_lambda_client)
+
+        mock_logs_client = mocker.Mock()
+        mock_logs_client.get_function_logs = AsyncMock(return_value=[])
+        mocker.patch("app.api.v1.routers.runs.AWSLogsClient", return_value=mock_logs_client)
+
+        # Create custom request with the modified data
+        client = TestClient(app)
+        api_path = f"{settings.API_PREFIX}/v1/runs"
+        files = {
+            "skill": ("test_skill.zip", io.BytesIO(TEST_CONTENT), "application/zip"),
+        }
+
+        # Execute
+        response = client.post(api_path, data=modified_data, files=files, headers={"Authorization": TEST_TOKEN})
+
+        # Assert
+        assert response.status_code == status.HTTP_200_OK
+
+        # Parse the streaming response
+        response_data = parse_streaming_response(response)
+
+        # Check for error response
+        final_message = response_data[-1]
+        assert final_message["code"] == "PROCESSING_ERROR"
+        assert final_message["success"] is False
+        assert f"Could not find skill {TEST_SKILL_NAME} for agent {TEST_AGENT_NAME}" in final_message["data"]["error"]
+
+    def test_empty_skill_zip_bytes(self, post_run_request_factory: Callable[[], Any], mocker: MockerFixture) -> None:
+        """Test error when skill_zip_bytes is empty after processing."""
+        # Mock process_skill to return empty skill_zip_bytes
+        mock_process_result = {
+            "message": "Skill processed successfully",
+            "data": {
+                "skill_name": TEST_SKILL_NAME,
+            },
+            "success": True,
+            "code": "SKILL_PROCESSED",
+        }
+
+        mocker.patch(
+            "app.api.v1.routers.runs.process_skill",
+            new=AsyncMock(
+                return_value=(
+                    mock_process_result,
+                    None,  # Empty skill_zip_bytes
+                )
+            ),
+        )
+
+        # Mock lambda client and its methods to avoid any real AWS calls
+        mock_lambda_client = mocker.Mock()
+        mock_lambda_client.delete_function.return_value = None
+
+        mocker.patch("app.api.v1.routers.runs.AWSLambdaClient", return_value=mock_lambda_client)
+
+        # Mock the logs client as well
+        mock_logs_client = mocker.Mock()
+        mock_logs_client.get_function_logs = AsyncMock(return_value=[])
+
+        mocker.patch("app.api.v1.routers.runs.AWSLogsClient", return_value=mock_logs_client)
+
+        # Execute
+        response = post_run_request_factory()
+
+        # Assert
+        assert response.status_code == status.HTTP_200_OK
+
+        # Parse the streaming response
+        response_data = parse_streaming_response(response)
+
+        # Check for error response
+        final_message = response_data[-1]
+        assert final_message["code"] == "PROCESSING_ERROR"
+        assert final_message["success"] is False
+        assert "Failed to process skill, aborting test run" in final_message["data"]["error"]

--- a/app/api/v1/routers/tests/test_runs.py
+++ b/app/api/v1/routers/tests/test_runs.py
@@ -77,6 +77,16 @@ def run_skill_request_data() -> dict[str, Any]:
         "test_definition": json.dumps(test_definition),
         "skill_name": TEST_SKILL_NAME,
         "agent_name": TEST_AGENT_NAME,
+        "skill_credentials": json.dumps(
+            {
+                "credential-test-key": "test-value",
+            }
+        ),
+        "skill_globals": json.dumps(
+            {
+                "global-test-key": "test-value",
+            }
+        ),
         "toolkit_version": "1.0.0",
     }
 
@@ -250,6 +260,8 @@ class TestRunSkillEndpoint:
                     "test_definition": json.dumps({"tests": {}}),
                     "skill_name": TEST_SKILL_NAME,
                     "agent_name": TEST_AGENT_NAME,
+                    "skill_credentials": json.dumps({}),
+                    "skill_globals": json.dumps({}),
                     "toolkit_version": "1.0.0",
                 },
                 {},  # No skill file
@@ -265,6 +277,8 @@ class TestRunSkillEndpoint:
                     "test_definition": json.dumps({"tests": {}}),
                     "skill_name": TEST_SKILL_NAME,
                     "agent_name": TEST_AGENT_NAME,
+                    "skill_credentials": json.dumps({}),
+                    "skill_globals": json.dumps({}),
                     "toolkit_version": "1.0.0",
                 },
                 {

--- a/app/api/v1/routes.py
+++ b/app/api/v1/routes.py
@@ -1,10 +1,12 @@
 """
 Main API router that includes all sub-routers.
 """
+
 from fastapi import APIRouter
 
 from app.api.v1.routers.agents import router as agents_router
 from app.api.v1.routers.health import router as health_router
+from app.api.v1.routers.runs import router as runs_router
 
 # Create main API router
 router = APIRouter(prefix="/v1")
@@ -12,3 +14,4 @@ router = APIRouter(prefix="/v1")
 # Include sub-routers
 router.include_router(health_router, prefix="/health", tags=["Health"])
 router.include_router(agents_router, prefix="/agents", tags=["Agents"])
+router.include_router(runs_router, prefix="/runs", tags=["Runs"])

--- a/app/services/skill/templates/lambda_function.py.template
+++ b/app/services/skill/templates/lambda_function.py.template
@@ -9,8 +9,12 @@ def lambda_handler(event, context):
     session_attributes = event.get('sessionAttributes')
     credentials = json.loads(session_attributes.get('credentials'))
     globals = json.loads(session_attributes.get('globals'))
+
+    parameters_map = {}
+    for param in parameters:
+        parameters_map[param["name"]] = param["value"]
             
-    context: Context = Context(credentials=credentials, parameters=parameters, globals=globals)
+    context: Context = Context(credentials=credentials, parameters=parameters_map, globals=globals)
     result, format = {class_name}(context)
 
     responseBody = {
@@ -26,7 +30,7 @@ def lambda_handler(event, context):
             'responseBody': responseBody
         },
         'promptSessionAttributes': {
-            'format_guidelines': format
+            'alwaysFormat': f"<example>{format}</example>"
         }
     }
 


### PR DESCRIPTION
- Implement `/runs` endpoint for running skill tests
- Create comprehensive test run workflow with streaming response
- Support Lambda function creation, invocation, and log retrieval
- Handle skill processing, test case execution, and error scenarios
- Integrate with AWS Lambda and CloudWatch Logs clients