### PR TITLE
feat: Retrieve Lambda function logs directly in invoke method

### DIFF
--- a/app/api/v1/routers/runs.py
+++ b/app/api/v1/routers/runs.py
@@ -174,20 +174,11 @@ async def run_skill_test(  # noqa: PLR0915
                     lambda_function.function_arn, test_event
                 )
 
-                # Get lambda function logs
-                logs_client = AWSLogsClient()
-                logs = await logs_client.get_function_logs(
-                    function_name=lambda_function.function_name,
-                    request_id=invoke_result.get("request_id"),
-                    start_time=invoke_start_time,
-                    end_time=invoke_end_time,
-                )
-
                 test_response: CLIResponse = {
                     "message": "Test case completed",
                     "data": {
                         "test_case": test_case,
-                        "logs": logs,
+                        "logs": invoke_result.get("logs"),
                         "duration": invoke_end_time - invoke_start_time,
                         "test_status_code": invoke_result.get("status_code"),
                         "test_response": invoke_result.get("response"),

--- a/app/api/v1/routers/runs.py
+++ b/app/api/v1/routers/runs.py
@@ -13,7 +13,7 @@ from fastapi.responses import StreamingResponse
 from starlette.datastructures import UploadFile
 
 from app.api.v1.models.requests import RunSkillRequestModel
-from app.clients.aws import AWSLambdaClient, AWSLogsClient
+from app.clients.aws import AWSLambdaClient
 from app.core.response import CLIResponse, send_response
 from app.services.skill.packager import process_skill
 

--- a/app/api/v1/routers/tests/test_runs.py
+++ b/app/api/v1/routers/tests/test_runs.py
@@ -195,15 +195,6 @@ class TestRunSkillEndpoint:
         mock_lambda_client.delete_function = mocker.MagicMock(return_value=None)
         mocker.patch("app.api.v1.routers.runs.AWSLambdaClient", return_value=mock_lambda_client)
 
-        # Mock logs client
-        mock_logs_client = mocker.MagicMock()
-        mock_logs = [
-            {"timestamp": TEST_START_TIME, "message": "START RequestId: test-request-id"},
-            {"timestamp": TEST_END_TIME, "message": "END RequestId: test-request-id"},
-        ]
-        mock_logs_client.get_function_logs = AsyncMock(return_value=mock_logs)
-        mocker.patch("app.api.v1.routers.runs.AWSLogsClient", return_value=mock_logs_client)
-
         # Mock asyncio.sleep to avoid delays in tests
         mocker.patch("asyncio.sleep", new=AsyncMock(return_value=None))
 
@@ -312,10 +303,6 @@ class TestRunSkillEndpoint:
         mock_lambda_client.delete_function = mocker.MagicMock(return_value=None)
         mocker.patch("app.api.v1.routers.runs.AWSLambdaClient", return_value=mock_lambda_client)
 
-        mock_logs_client = mocker.MagicMock()
-        mock_logs_client.get_function_logs = AsyncMock(return_value=[])
-        mocker.patch("app.api.v1.routers.runs.AWSLogsClient", return_value=mock_logs_client)
-
         # Mock asyncio.sleep
         mocker.patch("asyncio.sleep", new=AsyncMock(return_value=None))
 
@@ -360,11 +347,6 @@ class TestRunSkillEndpoint:
         mock_lambda_client.create_function = mocker.MagicMock(side_effect=ValueError("Function creation failed"))
         mock_lambda_client.delete_function = mocker.MagicMock(return_value=None)
         mocker.patch("app.api.v1.routers.runs.AWSLambdaClient", return_value=mock_lambda_client)
-
-        # Mock Logs client
-        mock_logs_client = mocker.MagicMock()
-        mock_logs_client.get_function_logs = AsyncMock(return_value=[])
-        mocker.patch("app.api.v1.routers.runs.AWSLogsClient", return_value=mock_logs_client)
 
         # Mock asyncio.sleep
         mocker.patch("asyncio.sleep", new=AsyncMock(return_value=None))
@@ -415,11 +397,6 @@ class TestRunSkillEndpoint:
         mock_lambda_client.wait_for_function_active = AsyncMock(return_value=False)
         mock_lambda_client.delete_function = mocker.MagicMock(return_value=None)
         mocker.patch("app.api.v1.routers.runs.AWSLambdaClient", return_value=mock_lambda_client)
-
-        # Mock Logs client
-        mock_logs_client = mocker.MagicMock()
-        mock_logs_client.get_function_logs = AsyncMock(return_value=[])
-        mocker.patch("app.api.v1.routers.runs.AWSLogsClient", return_value=mock_logs_client)
 
         # Mock asyncio.sleep
         mocker.patch("asyncio.sleep", new=AsyncMock(return_value=None))
@@ -474,11 +451,6 @@ class TestRunSkillEndpoint:
         mock_lambda_client.delete_function = mocker.MagicMock(return_value=None)
         mocker.patch("app.api.v1.routers.runs.AWSLambdaClient", return_value=mock_lambda_client)
 
-        # Mock Logs client
-        mock_logs_client = mocker.MagicMock()
-        mock_logs_client.get_function_logs = AsyncMock(return_value=[])
-        mocker.patch("app.api.v1.routers.runs.AWSLogsClient", return_value=mock_logs_client)
-
         # Mock asyncio.sleep
         mocker.patch("asyncio.sleep", new=AsyncMock(return_value=None))
 
@@ -522,11 +494,6 @@ class TestRunSkillEndpoint:
         )
         mocker.patch("app.api.v1.routers.runs.AWSLambdaClient", return_value=mock_lambda_client)
 
-        # Mock Logs client
-        mock_logs_client = mocker.MagicMock()
-        mock_logs_client.get_function_logs = AsyncMock(return_value=[])
-        mocker.patch("app.api.v1.routers.runs.AWSLogsClient", return_value=mock_logs_client)
-
         # Mock asyncio.sleep
         mocker.patch("asyncio.sleep", new=AsyncMock(return_value=None))
 
@@ -561,10 +528,6 @@ class TestRunSkillEndpoint:
         mock_lambda_client = mocker.MagicMock()
         mock_lambda_client.delete_function = mocker.MagicMock(return_value=None)
         mocker.patch("app.api.v1.routers.runs.AWSLambdaClient", return_value=mock_lambda_client)
-
-        mock_logs_client = mocker.MagicMock()
-        mock_logs_client.get_function_logs = AsyncMock(return_value=[])
-        mocker.patch("app.api.v1.routers.runs.AWSLogsClient", return_value=mock_logs_client)
 
         # Mock asyncio.sleep
         mocker.patch("asyncio.sleep", new=AsyncMock(return_value=None))
@@ -619,10 +582,6 @@ class TestRunSkillEndpoint:
         mock_lambda_client = mocker.MagicMock()
         mock_lambda_client.delete_function = mocker.MagicMock(return_value=None)
         mocker.patch("app.api.v1.routers.runs.AWSLambdaClient", return_value=mock_lambda_client)
-
-        mock_logs_client = mocker.MagicMock()
-        mock_logs_client.get_function_logs = AsyncMock(return_value=[])
-        mocker.patch("app.api.v1.routers.runs.AWSLogsClient", return_value=mock_logs_client)
 
         # Mock asyncio.sleep
         mocker.patch("asyncio.sleep", new=AsyncMock(return_value=None))
@@ -681,11 +640,6 @@ class TestRunSkillEndpoint:
         mock_lambda_client = mocker.MagicMock()
         mock_lambda_client.delete_function = mocker.MagicMock(return_value=None)
         mocker.patch("app.api.v1.routers.runs.AWSLambdaClient", return_value=mock_lambda_client)
-
-        # Mock Logs client
-        mock_logs_client = mocker.MagicMock()
-        mock_logs_client.get_function_logs = AsyncMock(return_value=[])
-        mocker.patch("app.api.v1.routers.runs.AWSLogsClient", return_value=mock_logs_client)
 
         # Mock asyncio.sleep
         mocker.patch("asyncio.sleep", new=AsyncMock(return_value=None))

--- a/app/clients/aws/lambda_client.py
+++ b/app/clients/aws/lambda_client.py
@@ -98,10 +98,15 @@ class AWSLambdaClient:
         # Decode base64 encoded logs
         logs = base64.b64decode(invoke_response["LogResult"]).decode("utf-8")
 
+        request_id = invoke_response["ResponseMetadata"]["RequestId"]
+
+        # Remove lines that contain RequestId
+        logs = "\n".join([line for line in logs.split("\n") if request_id not in line])
+
         result = {
             "status_code": invoke_response["StatusCode"],
             "response": json.loads(invoke_response["Payload"].read()),
-            "request_id": invoke_response["ResponseMetadata"]["RequestId"],
+            "request_id": request_id,
             "logs": logs,
         }
         return result, start_time, end_time

--- a/app/clients/aws/tests/test_lambda_client.py
+++ b/app/clients/aws/tests/test_lambda_client.py
@@ -1,3 +1,4 @@
+import base64
 import datetime
 import json
 from io import BytesIO
@@ -166,6 +167,7 @@ class TestAWSLambdaClient:
             "StatusCode": HTTP_STATUS_OK,
             "Payload": mock_payload,
             "ResponseMetadata": {"RequestId": MOCK_REQUEST_ID},
+            "LogResult": base64.b64encode(b"test log"),
         }
 
         # Directly patch datetime.now to return our fixed times
@@ -178,11 +180,15 @@ class TestAWSLambdaClient:
 
         # Assert
         mock_lambda_client.invoke.assert_called_once_with(
-            FunctionName=TEST_FUNCTION_ARN, InvocationType="RequestResponse", Payload=json.dumps(test_event)
+            FunctionName=TEST_FUNCTION_ARN,
+            InvocationType="RequestResponse",
+            Payload=json.dumps(test_event),
+            LogType="Tail",
         )
 
         assert result["status_code"] == HTTP_STATUS_OK
         assert result["response"] == {"result": "success"}
+        assert result["logs"] == "test log"
         assert start_time == MOCK_START_TIME.timestamp()
         assert end_time == MOCK_END_TIME.timestamp()
 


### PR DESCRIPTION
- Update AWSLambdaClient to capture Lambda function logs during invocation
- Add LogType="Tail" to retrieve base64 encoded logs
- Decode logs and include them in the invoke result
- Modify runs router to use logs from invoke result instead of separate log retrieval
- Update test_lambda_client to verify log retrieval and decoding