### PR TITLE
refactor: Rename skill-related components to tool-related

### DIFF
--- a/app/api/v1/models/requests.py
+++ b/app/api/v1/models/requests.py
@@ -9,14 +9,14 @@ class BaseRequestModel(BaseModel):
     toolkit_version: str
 
 
-class RunSkillRequestModel(BaseRequestModel):
-    """Run skill request model."""
+class RunToolRequestModel(BaseRequestModel):
+    """Run tool request model."""
 
     test_definition: Json
-    skill_name: str
+    tool_name: str
     agent_name: str
-    skill_credentials: Json
-    skill_globals: Json
+    tool_credentials: Json
+    tool_globals: Json
 
 
 class VerifyPermissionRequestModel(BaseModel):

--- a/app/api/v1/routers/agents.py
+++ b/app/api/v1/routers/agents.py
@@ -14,7 +14,7 @@ from starlette.datastructures import UploadFile
 from app.api.v1.models.requests import BaseRequestModel
 from app.clients.nexus_client import NexusClient
 from app.core.response import CLIResponse, send_response
-from app.services.skill.packager import process_skill
+from app.services.tool.packager import process_tool
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -27,12 +27,12 @@ async def configure_agents(
     authorization: Annotated[str, Header()],
 ) -> StreamingResponse:
     """
-    Upload multiple files for skill processing.
+    Upload multiple files for tool processing.
 
     Args:
         request: FastAPI request object to access form data and files
         project_uuid: UUID of the project
-        definition: JSON containing agent definitions
+        definition: JSON containing tool definitions
         authorization: Authorization header for Nexus API calls
 
     Returns:
@@ -45,14 +45,14 @@ async def configure_agents(
     # Access the form data with files
     form = await request.form()
 
-    # Extract and process skill files
-    skills_folders_zips = await extract_skill_files(form)
-    skill_count = len(skills_folders_zips)
-    logger.info(f"Found {skill_count} skill folders to process for project {data.project_uuid}")
-    logger.debug(f"Skill keys: {list(skills_folders_zips.keys())}")
+    # Extract and process tool files
+    tools_folders_zips = await extract_tool_files(form)
+    tool_count = len(tools_folders_zips)
+    logger.info(f"Found {tool_count} tool folders to process for project {data.project_uuid}")
+    logger.debug(f"Tool keys: {list(tools_folders_zips.keys())}")
 
     # Create file names list for streaming
-    skills_folders_zips_entries = await read_skills_content(skills_folders_zips)
+    tools_folders_zips_entries = await read_tools_content(tools_folders_zips)
 
     # Async generator for streaming responses
     async def response_stream() -> AsyncIterator[bytes]:
@@ -62,54 +62,54 @@ async def configure_agents(
                 "message": "Processing agents...",
                 "data": {
                     "project_uuid": str(data.project_uuid),
-                    "total_files": skill_count,
+                    "total_files": tool_count,
                 },
                 "success": True,
                 "progress": 0.01,
                 "code": "PROCESSING_STARTED",
             }
-            logger.info(f"Starting processing for {skill_count} skills")
+            logger.info(f"Starting processing for {tool_count} tools")
             yield send_response(initial_data, request_id=request_id)
 
-            skill_mapping = {}
+            tool_mapping = {}
             processed_count = 0
 
-            # Process each skill file
-            for key, folder_zip in skills_folders_zips_entries:
-                agent_slug, skill_slug = key.split(":")
+            # Process each tool file
+            for key, folder_zip in tools_folders_zips_entries:
+                agent_slug, tool_slug = key.split(":")
                 processed_count += 1
 
-                # Process the skill
-                response, skill_zip_bytes = await process_skill(
+                # Process the tool
+                response, tool_zip_bytes = await process_tool(
                     folder_zip,
                     key,
                     str(data.project_uuid),
                     agent_slug,
-                    skill_slug,
+                    tool_slug,
                     data.definition,
                     processed_count,
-                    skill_count,
+                    tool_count,
                     data.toolkit_version,
                 )
 
-                # Send response for this skill
+                # Send response for this tool
                 yield send_response(response, request_id=request_id)
 
-                # If skill processing failed, stop and raise an exception
-                if not skill_zip_bytes:
+                # If tool processing failed, stop and raise an exception
+                if not tool_zip_bytes:
                     response_data: dict = response.get("data") or {}
-                    error_message = response_data.get("error", "Unknown error processing skill")
-                    raise Exception(f"Failed to process skill {key}: {error_message}")
+                    error_message = response_data.get("error", "Unknown error processing tool")
+                    raise Exception(f"Failed to process tool {key}: {error_message}")
 
                 # Add to mapping if successful (we'll only get here if processing succeeded)
-                skill_mapping[key] = skill_zip_bytes
+                tool_mapping[key] = tool_zip_bytes
 
             # Send progress update for Nexus upload
             nexus_response: CLIResponse = {
                 "message": "Updating your agents...",
                 "data": {
                     "project_uuid": str(data.project_uuid),
-                    "skill_count": len(skill_mapping),
+                    "tool_count": len(tool_mapping),
                 },
                 "success": True,
                 "code": "NEXUS_UPLOAD_STARTED",
@@ -117,9 +117,9 @@ async def configure_agents(
             }
             yield send_response(nexus_response, request_id=request_id)
 
-            # Push to Nexus - always push, even if no skills
+            # Push to Nexus - always push, even if no tools
             success, error_response = push_to_nexus(
-                str(data.project_uuid), data.definition, skill_mapping, request_id, authorization
+                str(data.project_uuid), data.definition, tool_mapping, request_id, authorization
             )
 
             if not success and error_response is not None:
@@ -136,8 +136,8 @@ async def configure_agents(
                 "message": "Agents processed successfully",
                 "data": {
                     "project_uuid": str(data.project_uuid),
-                    "total_files": skill_count,
-                    "processed_files": len(skill_mapping),
+                    "total_files": tool_count,
+                    "processed_files": len(tool_mapping),
                     "status": "completed",
                 },
                 "success": True,
@@ -164,51 +164,51 @@ async def configure_agents(
 
 
 # Utility functions below this point
-async def extract_skill_files(form: Any) -> dict[str, UploadFile]:
+async def extract_tool_files(form: Any) -> dict[str, UploadFile]:
     """
-    Extract skill files from form data.
+    Extract tool files from form data.
 
     Args:
         form: The form data containing files (FormData from FastAPI)
 
     Returns:
-        Dictionary of agent:skill keys to UploadFile objects
+        Dictionary of agent:tool keys to UploadFile objects
     """
-    skills_folders_zips = {}
+    tools_folders_zips = {}
     for key, value in form.items():
         if isinstance(value, UploadFile) and ":" in key:
-            skills_folders_zips[key] = value
+            tools_folders_zips[key] = value
 
-    return skills_folders_zips
+    return tools_folders_zips
 
 
-async def read_skills_content(skills_folders_zips: dict[str, UploadFile]) -> list[tuple[str, bytes]]:
+async def read_tools_content(tools_folders_zips: dict[str, UploadFile]) -> list[tuple[str, bytes]]:
     """
-    Read the content of each skill file.
+    Read the content of each tool file.
 
     Args:
-        skills_folders_zips: Dictionary of skill keys to file objects
+        tools_folders_zips: Dictionary of tool keys to file objects
 
     Returns:
         List of tuples containing (key, file_content)
     """
-    return [(key, await file.read()) for key, file in skills_folders_zips.items()]
+    return [(key, await file.read()) for key, file in tools_folders_zips.items()]
 
 
 def push_to_nexus(
     project_uuid: str,
     definition: dict[str, Any],
-    skill_mapping: dict[str, Any],
+    tool_mapping: dict[str, Any],
     request_id: str,
     authorization: str,
 ) -> tuple[bool, CLIResponse | None]:
     """
-    Push processed skills to Nexus.
+    Push processed tools to Nexus.
 
     Args:
         project_uuid: The UUID of the project
         definition: The agent definition
-        skill_mapping: Dictionary of processed skills
+        tool_mapping: Dictionary of processed tools
         request_id: The request ID for correlation
         authorization: The authorization header value
 
@@ -216,15 +216,15 @@ def push_to_nexus(
         Tuple of (success, response)
     """
     try:
-        logger.info(f"Sending {len(skill_mapping)} processed skills to Nexus for project {project_uuid}")
+        logger.info(f"Sending {len(tool_mapping)} processed tools to Nexus for project {project_uuid}")
         nexus_client = NexusClient(authorization)
 
         # We need to change the entrypoint to the lambda function we've created
         for _, agent_data in definition["agents"].items():
-            for skill in agent_data["skills"]:
-                skill["source"]["entrypoint"] = "lambda_function.lambda_handler"
+            for tool in agent_data["tools"]:
+                tool["source"]["entrypoint"] = "lambda_function.lambda_handler"
 
-        response = nexus_client.push_agents(str(project_uuid), definition, skill_mapping)
+        response = nexus_client.push_agents(str(project_uuid), definition, tool_mapping)
 
         if response.status_code != status.HTTP_200_OK:
             raise Exception(f"Failed to push agents: {response.status_code} {response.text}")
@@ -240,7 +240,7 @@ def push_to_nexus(
             "data": {
                 "project_uuid": str(project_uuid),
                 "error": str(e),
-                "skills_processed": len(skill_mapping),
+                "tools_processed": len(tool_mapping),
             },
             "success": False,
             "code": "NEXUS_UPLOAD_ERROR",

--- a/app/api/v1/routers/runs.py
+++ b/app/api/v1/routers/runs.py
@@ -1,5 +1,5 @@
 """
-Skill runs endpoints for handling file uploads and processing.
+Tool runs endpoints for handling file uploads and processing.
 """
 
 import json
@@ -12,19 +12,19 @@ from fastapi import APIRouter, Form, Header, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from starlette.datastructures import UploadFile
 
-from app.api.v1.models.requests import RunSkillRequestModel
+from app.api.v1.models.requests import RunToolRequestModel
 from app.clients.aws import AWSLambdaClient
 from app.core.response import CLIResponse, send_response
-from app.services.skill.packager import process_skill
+from app.services.tool.packager import process_tool
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
 @router.post("")
-async def run_skill_test(  # noqa: PLR0915
+async def run_tool_test(  # noqa: PLR0915
     request: Request,
-    data: Annotated[RunSkillRequestModel, Form()],
+    data: Annotated[RunToolRequestModel, Form()],
     authorization: Annotated[str, Header()],
 ) -> StreamingResponse:
     request_id = str(uuid4())
@@ -34,16 +34,16 @@ async def run_skill_test(  # noqa: PLR0915
     # Access the form data with files
     form = await request.form()
 
-    # Extract and process skill files
-    skill_folder_zip = form.get("skill")
+    # Extract and process tool files
+    tool_folder_zip = form.get("tool")
 
-    if not skill_folder_zip or not isinstance(skill_folder_zip, UploadFile):
-        raise HTTPException(status_code=400, detail="Skill folder zip is required")
+    if not tool_folder_zip or not isinstance(tool_folder_zip, UploadFile):
+        raise HTTPException(status_code=400, detail="Tool folder zip is required")
 
-    folder_zip = await skill_folder_zip.read()
+    folder_zip = await tool_folder_zip.read()
 
-    logger.info(f"Found skill folder to process for project {data.project_uuid}")
-    logger.debug(f"Skill folder zip: {skill_folder_zip}")
+    logger.info(f"Found tool folder to process for project {data.project_uuid}")
+    logger.debug(f"Tool folder zip: {tool_folder_zip}")
 
     function_name = f"cli-{str(uuid4())}"
     lambda_client = AWSLambdaClient()
@@ -59,9 +59,9 @@ async def run_skill_test(  # noqa: PLR0915
                 "code": "PROCESSING_STARTED",
             }
             yield send_response(initial_data, request_id=request_id)
-            logger.info(f"Starting test run for skill {data.skill_name} by {data.agent_name}")
+            logger.info(f"Starting test run for tool {data.tool_name} by {data.agent_name}")
 
-            # Get skill entrypoint
+            # Get tool entrypoint
             agent_info = next(
                 (agent for agent in data.definition["agents"].values() if agent.get("name") == data.agent_name),
                 None,
@@ -72,34 +72,34 @@ async def run_skill_test(  # noqa: PLR0915
 
             logger.debug(f"Agent info: {agent_info}")
 
-            skill_info = next(
-                (skill for skill in agent_info["skills"] if skill["name"] == data.skill_name),
+            tool_info = next(
+                (tool for tool in agent_info["tools"] if tool["name"] == data.tool_name),
                 None,
             )
 
-            if not skill_info:
-                raise ValueError(f"Could not find skill {data.skill_name} for agent {data.agent_name} in definition")
+            if not tool_info:
+                raise ValueError(f"Could not find tool {data.tool_name} for agent {data.agent_name} in definition")
 
-            logger.debug(f"Skill info: {skill_info}")
+            logger.debug(f"Tool info: {tool_info}")
 
-            # Process the skill folder zip
-            response, skill_zip_bytes = await process_skill(
+            # Process the tool folder zip
+            response, tool_zip_bytes = await process_tool(
                 folder_zip,
-                f"{agent_info.get('slug')}:{skill_info.get('slug')}",
+                f"{agent_info.get('slug')}:{tool_info.get('slug')}",
                 str(data.project_uuid),
                 agent_info.get("slug"),
-                skill_info.get("slug"),
+                tool_info.get("slug"),
                 data.definition,
                 1,
                 1,
                 data.toolkit_version,
             )
 
-            # Send response for this skill
+            # Send response for this tool
             yield send_response(response, request_id=request_id)
 
-            if not skill_zip_bytes:
-                raise ValueError("Failed to process skill, aborting test run")
+            if not tool_zip_bytes:
+                raise ValueError("Failed to process tool, aborting test run")
 
             response = {
                 "message": "Creating lambda function",
@@ -116,8 +116,8 @@ async def run_skill_test(  # noqa: PLR0915
             lambda_function = lambda_client.create_function(
                 function_name=function_name,
                 handler="lambda_function.lambda_handler",
-                code=skill_zip_bytes,
-                description=f"CLI run for skill {data.skill_name} by {data.agent_name}. Project: {data.project_uuid}",
+                code=tool_zip_bytes,
+                description=f"CLI run for tool {data.tool_name} by {data.agent_name}. Project: {data.project_uuid}",
             )
 
             if not lambda_function.function_arn or not lambda_function.function_name:
@@ -140,7 +140,7 @@ async def run_skill_test(  # noqa: PLR0915
             yield send_response(response, request_id=request_id)
 
             for test_case, test_data in data.test_definition.get("tests", {}).items():
-                logger.info(f"Running test case {test_case} for skill {data.skill_name} by {data.agent_name}")
+                logger.info(f"Running test case {test_case} for tool {data.tool_name} by {data.agent_name}")
 
                 response = {
                     "message": f"Running test case {test_case}",
@@ -164,8 +164,8 @@ async def run_skill_test(  # noqa: PLR0915
                     "function": lambda_function.function_name,
                     "parameters": parameters,
                     "sessionAttributes": {
-                        "credentials": json.dumps(test_data.get("credentials", data.skill_credentials)),
-                        "globals": json.dumps(test_data.get("globals", data.skill_globals)),
+                        "credentials": json.dumps(test_data.get("credentials", data.tool_credentials)),
+                        "globals": json.dumps(test_data.get("globals", data.tool_globals)),
                     },
                 }
 

--- a/app/api/v1/routers/tests/test_agents.py
+++ b/app/api/v1/routers/tests/test_agents.py
@@ -21,8 +21,8 @@ from app.tests.utils import AsyncMock
 # Common test constants
 TEST_CONTENT = b"test content"
 TEST_AGENT = "test-agent"
-TEST_SKILL = "test-skill"
-TEST_SKILL_KEY = f"{TEST_AGENT}:{TEST_SKILL}"
+TEST_TOOL = "test-tool"
+TEST_TOOL_KEY = f"{TEST_AGENT}:{TEST_TOOL}"
 TEST_TOKEN = "Bearer test-token"
 
 
@@ -64,12 +64,12 @@ def agent_definition() -> dict[str, Any]:
                 "name": "Test Agent",
                 "slug": TEST_AGENT,
                 "description": "A test agent",
-                "skills": [
+                "tools": [
                     {
-                        "slug": TEST_SKILL,
-                        "name": "Test Skill",
-                        "description": "A test skill",
-                        "source": {"entrypoint": "main.TestSkill"},
+                        "slug": TEST_TOOL,
+                        "name": "Test Tool",
+                        "description": "A test tool",
+                        "source": {"entrypoint": "main.TestTool"},
                     }
                 ],
             }
@@ -96,7 +96,7 @@ def post_request_factory(
                 "toolkit_version": "1.0.0",  # Add default toolkit version for tests
             },
             files={
-                TEST_SKILL_KEY: ("test.zip", io.BytesIO(TEST_CONTENT), "application/zip"),
+                TEST_TOOL_KEY: ("test.zip", io.BytesIO(TEST_CONTENT), "application/zip"),
             },
             headers=auth_header,
         )
@@ -155,36 +155,36 @@ class TestAgentConfigEndpoint:
     def mock_success_dependencies(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Mock dependencies for successful test."""
         mock_upload_file = UploadFile(
-            filename="test_skill.zip",
+            filename="test_tool.zip",
             file=io.BytesIO(TEST_CONTENT),
         )
         monkeypatch.setattr(
-            "app.api.v1.routers.agents.extract_skill_files",
-            AsyncMock(return_value={TEST_SKILL_KEY: mock_upload_file}),
+            "app.api.v1.routers.agents.extract_tool_files",
+            AsyncMock(return_value={TEST_TOOL_KEY: mock_upload_file}),
         )
         monkeypatch.setattr(
-            "app.api.v1.routers.agents.read_skills_content",
-            AsyncMock(return_value=[(TEST_SKILL_KEY, TEST_CONTENT)]),
+            "app.api.v1.routers.agents.read_tools_content",
+            AsyncMock(return_value=[(TEST_TOOL_KEY, TEST_CONTENT)]),
         )
         process_response = {
-            "message": "Skill processed successfully",
+            "message": "Tool processed successfully",
             "data": {
-                "skill_name": TEST_SKILL,
+                "tool_name": TEST_TOOL,
                 "agent_name": TEST_AGENT,
                 "size_kb": 1.0,
                 "progress": 100,
             },
             "success": True,
-            "code": "SKILL_PROCESSED",
+            "code": "TOOL_PROCESSED",
         }
 
-        # Use a custom mock for process_skill that accepts the toolkit_version parameter
-        async def mock_process_skill(*args: Any, **kwargs: Any) -> tuple[dict[str, Any], io.BytesIO]:
+        # Use a custom mock for process_tool that accepts the toolkit_version parameter
+        async def mock_process_tool(*args: Any, **kwargs: Any) -> tuple[dict[str, Any], io.BytesIO]:
             return (process_response, io.BytesIO(b"processed content"))
 
-        monkeypatch.setattr("app.services.skill.packager.process_skill", mock_process_skill)
+        monkeypatch.setattr("app.services.tool.packager.process_tool", mock_process_tool)
         monkeypatch.setattr(
-            "app.services.skill.packager.create_skill_zip", lambda *args, **kwargs: io.BytesIO(b"packed content")
+            "app.services.tool.packager.create_tool_zip", lambda *args, **kwargs: io.BytesIO(b"packed content")
         )
         monkeypatch.setattr(
             "app.api.v1.routers.agents.push_to_nexus",
@@ -231,7 +231,7 @@ class TestAgentConfigEndpoint:
                     "toolkit_version": "1.0.0",  # Add toolkit_version to avoid failing on that parameter
                 },
                 {
-                    TEST_SKILL_KEY: ("test.zip", io.BytesIO(b"test"), "application/zip"),
+                    TEST_TOOL_KEY: ("test.zip", io.BytesIO(b"test"), "application/zip"),
                 },
                 None,  # Use default auth header
                 status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -245,7 +245,7 @@ class TestAgentConfigEndpoint:
                     "definition": json.dumps({"agents": {}}),
                 },
                 {
-                    TEST_SKILL_KEY: ("test.zip", io.BytesIO(b"test"), "application/zip"),
+                    TEST_TOOL_KEY: ("test.zip", io.BytesIO(b"test"), "application/zip"),
                 },
                 None,  # Use default auth header
                 status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -260,7 +260,7 @@ class TestAgentConfigEndpoint:
                     "toolkit_version": "1.0.0",  # Add toolkit_version to avoid failing on that parameter
                 },
                 {
-                    TEST_SKILL_KEY: ("test.zip", io.BytesIO(b"test"), "application/zip"),
+                    TEST_TOOL_KEY: ("test.zip", io.BytesIO(b"test"), "application/zip"),
                 },
                 None,  # Use default auth header
                 status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -275,7 +275,7 @@ class TestAgentConfigEndpoint:
                     "toolkit_version": "1.0.0",  # Add toolkit_version to avoid failing on that parameter
                 },
                 {
-                    TEST_SKILL_KEY: ("test.zip", io.BytesIO(TEST_CONTENT), "application/zip"),
+                    TEST_TOOL_KEY: ("test.zip", io.BytesIO(TEST_CONTENT), "application/zip"),
                 },
                 {
                     "X-CLI-Version": settings.CLI_MINIMUM_VERSION,
@@ -285,14 +285,14 @@ class TestAgentConfigEndpoint:
                 None,  # No custom setup
             ),
             (
-                "process_skill_error",
+                "process_tool_error",
                 None,  # Will be set in the test
                 None,  # Will be set in the test
                 None,  # Use default auth header
                 status.HTTP_200_OK,
-                "Should handle process_skill error",
+                "Should handle process_tool error",
                 {
-                    "mock_process_skill": AsyncMock(side_effect=RuntimeError("Simulated error in processing")),
+                    "mock_process_tool": AsyncMock(side_effect=RuntimeError("Simulated error in processing")),
                 },
             ),
         ],
@@ -313,14 +313,14 @@ class TestAgentConfigEndpoint:
         mock_auth_middleware: None,
     ) -> None:
         """Test validation errors for agent config endpoint."""
-        # For the process_skill_error case, we need a special setup
-        if test_id == "process_skill_error":
+        # For the process_tool_error case, we need a special setup
+        if test_id == "process_tool_error":
             # Use the default post_request_factory
             # But first set up the mocks as defined in custom_setup
             if custom_setup:
                 for key, value in custom_setup.items():
-                    if key == "mock_process_skill":
-                        monkeypatch.setattr("app.services.skill.packager.process_skill", value)
+                    if key == "mock_process_tool":
+                        monkeypatch.setattr("app.services.tool.packager.process_tool", value)
 
             response = post_request_factory()
         else:
@@ -336,39 +336,39 @@ class TestAgentConfigEndpoint:
         self, post_request_factory: Callable[[], Any], mock_auth_middleware: None, mocker: MockerFixture
     ) -> None:
         """Test handling of error response from push_to_nexus."""
-        # Mock successful skill processing
+        # Mock successful tool processing
         process_response = {
-            "message": "Skill processed successfully",
+            "message": "Tool processed successfully",
             "data": {
-                "skill_name": TEST_SKILL,
+                "tool_name": TEST_TOOL,
                 "agent_name": TEST_AGENT,
                 "size_kb": 1.0,
                 "progress": 100,
             },
             "success": True,
-            "code": "SKILL_PROCESSED",
+            "code": "TOOL_PROCESSED",
         }
 
-        # Mock create_skill_zip to avoid zip file error
+        # Mock create_tool_zip to avoid zip file error
         mocker.patch(
-            "app.services.skill.packager.create_skill_zip",
+            "app.services.tool.packager.create_tool_zip",
             return_value=io.BytesIO(b"valid zip content"),
         )
 
-        # Mock process_skill to succeed
+        # Mock process_tool to succeed
         mocker.patch(
-            "app.services.skill.packager.process_skill",
+            "app.services.tool.packager.process_tool",
             new=AsyncMock(return_value=(process_response, io.BytesIO(b"processed content"))),
         )
 
-        # Mock extract_skill_files and read_skills_content to return test data
+        # Mock extract_tool_files and read_tools_content to return test data
         mocker.patch(
-            "app.api.v1.routers.agents.extract_skill_files",
-            new=AsyncMock(return_value={TEST_SKILL_KEY: mocker.Mock()}),
+            "app.api.v1.routers.agents.extract_tool_files",
+            new=AsyncMock(return_value={TEST_TOOL_KEY: mocker.Mock()}),
         )
         mocker.patch(
-            "app.api.v1.routers.agents.read_skills_content",
-            new=AsyncMock(return_value=[(TEST_SKILL_KEY, TEST_CONTENT)]),
+            "app.api.v1.routers.agents.read_tools_content",
+            new=AsyncMock(return_value=[(TEST_TOOL_KEY, TEST_CONTENT)]),
         )
 
         # Create a nexus error response
@@ -376,7 +376,7 @@ class TestAgentConfigEndpoint:
             "message": "Failed to push agents",
             "data": {
                 "error": "Error pushing to Nexus",
-                "skills_processed": 1,
+                "tools_processed": 1,
             },
             "success": False,
             "code": "NEXUS_UPLOAD_ERROR",
@@ -407,39 +407,39 @@ class TestAgentConfigEndpoint:
         self, post_request_factory: Callable[[], Any], mock_auth_middleware: None, mocker: MockerFixture
     ) -> None:
         """Test final success message in streaming response."""
-        # Mock successful skill processing
+        # Mock successful tool processing
         process_response = {
-            "message": "Skill processed successfully",
+            "message": "Tool processed successfully",
             "data": {
-                "skill_name": TEST_SKILL,
+                "tool_name": TEST_TOOL,
                 "agent_name": TEST_AGENT,
                 "size_kb": 1.0,
                 "progress": 100,
             },
             "success": True,
-            "code": "SKILL_PROCESSED",
+            "code": "TOOL_PROCESSED",
         }
 
-        # Mock create_skill_zip to avoid zip file error
+        # Mock create_tool_zip to avoid zip file error
         mocker.patch(
-            "app.services.skill.packager.create_skill_zip",
+            "app.services.tool.packager.create_tool_zip",
             return_value=io.BytesIO(b"valid zip content"),
         )
 
-        # Mock process_skill to succeed
+        # Mock process_tool to succeed
         mocker.patch(
-            "app.services.skill.packager.process_skill",
+            "app.services.tool.packager.process_tool",
             new=AsyncMock(return_value=(process_response, io.BytesIO(b"processed content"))),
         )
 
-        # Mock extract_skill_files and read_skills_content to return test data
+        # Mock extract_tool_files and read_tools_content to return test data
         mocker.patch(
-            "app.api.v1.routers.agents.extract_skill_files",
-            new=AsyncMock(return_value={TEST_SKILL_KEY: mocker.Mock()}),
+            "app.api.v1.routers.agents.extract_tool_files",
+            new=AsyncMock(return_value={TEST_TOOL_KEY: mocker.Mock()}),
         )
         mocker.patch(
-            "app.api.v1.routers.agents.read_skills_content",
-            new=AsyncMock(return_value=[(TEST_SKILL_KEY, TEST_CONTENT)]),
+            "app.api.v1.routers.agents.read_tools_content",
+            new=AsyncMock(return_value=[(TEST_TOOL_KEY, TEST_CONTENT)]),
         )
 
         # Mock push_to_nexus to succeed
@@ -462,13 +462,13 @@ class TestAgentConfigEndpoint:
         assert final_message["success"] is True, "Final message should have success=True"
         assert final_message["code"] == "PROCESSING_COMPLETED", "Final message should have code=PROCESSING_COMPLETED"
 
-    def test_push_to_nexus_with_no_skills(
+    def test_push_to_nexus_with_no_tools(
         self, post_request_factory: Callable[[], Any], mock_auth_middleware: None, mocker: MockerFixture
     ) -> None:
-        """Test pushing to Nexus when there are no skills."""
-        # Mock extract_skill_files and read_skills_content to return empty results
-        mocker.patch("app.api.v1.routers.agents.extract_skill_files", new=AsyncMock(return_value={}))
-        mocker.patch("app.api.v1.routers.agents.read_skills_content", new=AsyncMock(return_value=[]))
+        """Test pushing to Nexus when there are no tools."""
+        # Mock extract_tool_files and read_tools_content to return empty results
+        mocker.patch("app.api.v1.routers.agents.extract_tool_files", new=AsyncMock(return_value={}))
+        mocker.patch("app.api.v1.routers.agents.read_tools_content", new=AsyncMock(return_value=[]))
 
         # Create a mock response object
         mock_response = mocker.MagicMock(spec=requests.Response)
@@ -503,34 +503,34 @@ class TestAgentConfigEndpoint:
             "Final message should have code=PROCESSING_COMPLETED"
         )
 
-    def test_process_skill_failure_stops_processing(
+    def test_process_tool_failure_stops_processing(
         self, post_request_factory: Callable[[], Any], mock_auth_middleware: None, mocker: MockerFixture
     ) -> None:
-        """Test that processing stops on skill processing failure."""
-        error_message = "Error processing skill"
+        """Test that processing stops on tool processing failure."""
+        error_message = "Error processing tool"
 
         # Create an error response
         error_response = {
             "message": error_message,
             "data": {},
             "success": False,
-            "code": "SKILL_PROCESSING_ERROR",
+            "code": "TOOL_PROCESSING_ERROR",
         }
 
-        # Setup mocks to simulate skill processing failure using mocker
+        # Setup mocks to simulate tool processing failure using mocker
         mocker.patch(
-            "app.api.v1.routers.agents.extract_skill_files",
-            new=AsyncMock(return_value={TEST_SKILL_KEY: mocker.Mock()}),
+            "app.api.v1.routers.agents.extract_tool_files",
+            new=AsyncMock(return_value={TEST_TOOL_KEY: mocker.Mock()}),
         )
         mocker.patch(
-            "app.api.v1.routers.agents.read_skills_content",
-            new=AsyncMock(return_value=[(TEST_SKILL_KEY, TEST_CONTENT)]),
+            "app.api.v1.routers.agents.read_tools_content",
+            new=AsyncMock(return_value=[(TEST_TOOL_KEY, TEST_CONTENT)]),
         )
-        mocker.patch("app.services.skill.packager.process_skill", new=AsyncMock(return_value=(error_response, None)))
+        mocker.patch("app.services.tool.packager.process_tool", new=AsyncMock(return_value=(error_response, None)))
 
         # Mock push_to_nexus to ensure it's not called
         def mock_push_to_nexus(*args: Any, **kwargs: Any) -> Any:
-            pytest.fail("push_to_nexus should not be called after skill processing failure")
+            pytest.fail("push_to_nexus should not be called after tool processing failure")
 
         mocker.patch("app.api.v1.routers.agents.push_to_nexus", mock_push_to_nexus)
 
@@ -552,42 +552,42 @@ class TestAgentConfigEndpoint:
 class TestHelperFunctions:
     """Tests for helper functions in agents.py."""
 
-    def test_extract_skill_files(self) -> None:
-        """Test extracting skill files from form data."""
+    def test_extract_tool_files(self) -> None:
+        """Test extracting tool files from form data."""
         import asyncio
 
-        from app.api.v1.routers.agents import extract_skill_files
+        from app.api.v1.routers.agents import extract_tool_files
 
         mock_file = UploadFile(filename="test.zip", file=io.BytesIO(TEST_CONTENT))
         mock_form = {
             "project_uuid": "test-uuid",  # Not a file
             "definition": "{}",  # Not a file
-            TEST_SKILL_KEY: mock_file,  # Valid
+            TEST_TOOL_KEY: mock_file,  # Valid
             "invalid-key": mock_file,  # Invalid (no colon)
         }
 
-        result = asyncio.run(extract_skill_files(mock_form))
+        result = asyncio.run(extract_tool_files(mock_form))
         assert len(result) == 1, "Should extract one file"
-        assert TEST_SKILL_KEY in result, "Should extract valid file"
+        assert TEST_TOOL_KEY in result, "Should extract valid file"
         assert "invalid-key" not in result, "Should ignore invalid keys"
 
-    def test_read_skills_content(self) -> None:
-        """Test reading content from skill files."""
+    def test_read_tools_content(self) -> None:
+        """Test reading content from tool files."""
         import asyncio
 
-        from app.api.v1.routers.agents import read_skills_content
+        from app.api.v1.routers.agents import read_tools_content
 
         file1 = UploadFile(filename="test1.zip", file=io.BytesIO(b"content1"))
         file2 = UploadFile(filename="test2.zip", file=io.BytesIO(b"content2"))
-        skills_folders_zips = {"agent1:skill1": file1, "agent2:skill2": file2}
+        tools_folders_zips = {"agent1:tool1": file1, "agent2:tool2": file2}
 
         # Define constant for expected number of files
         expected_file_count = 2
 
-        result = asyncio.run(read_skills_content(skills_folders_zips))
+        result = asyncio.run(read_tools_content(tools_folders_zips))
         assert len(result) == expected_file_count, "Should read two files"
-        assert result[0][0] == "agent1:skill1" and result[0][1] == b"content1", "First content should match"
-        assert result[1][0] == "agent2:skill2" and result[1][1] == b"content2", "Second content should match"
+        assert result[0][0] == "agent1:tool1" and result[0][1] == b"content1", "First content should match"
+        assert result[1][0] == "agent2:tool2" and result[1][1] == b"content2", "Second content should match"
 
 
 class TestPushToNexus:
@@ -595,8 +595,8 @@ class TestPushToNexus:
 
     # Common test data
     project_uuid: ClassVar[str] = str(uuid4())
-    definition: ClassVar[dict[str, Any]] = {"agents": {TEST_AGENT: {"skills": []}}}
-    skill_mapping: ClassVar[dict[str, Any]] = {TEST_SKILL_KEY: io.BytesIO(b"skill content")}
+    definition: ClassVar[dict[str, Any]] = {"agents": {TEST_AGENT: {"tools": []}}}
+    tool_mapping: ClassVar[dict[str, Any]] = {TEST_TOOL_KEY: io.BytesIO(b"tool content")}
     request_id: ClassVar[str] = str(uuid4())
     authorization: ClassVar[str] = TEST_TOKEN
 
@@ -611,7 +611,7 @@ class TestPushToNexus:
             mp.setattr("app.api.v1.routers.agents.NexusClient", lambda auth: mock_client())
 
             success, response = push_to_nexus(
-                self.project_uuid, self.definition, self.skill_mapping, self.request_id, self.authorization
+                self.project_uuid, self.definition, self.tool_mapping, self.request_id, self.authorization
             )
 
         assert success is True, "Should report success"
@@ -630,7 +630,7 @@ class TestPushToNexus:
             mp.setattr("app.api.v1.routers.agents.NexusClient", lambda auth: MockNexusClient())
 
             success, response = push_to_nexus(
-                self.project_uuid, self.definition, self.skill_mapping, self.request_id, self.authorization
+                self.project_uuid, self.definition, self.tool_mapping, self.request_id, self.authorization
             )
 
         assert success is False, "Should report failure"
@@ -658,7 +658,7 @@ class TestPushToNexus:
             mp.setattr("app.api.v1.routers.agents.NexusClient", lambda auth: mock_client())
 
             success, response = push_to_nexus(
-                self.project_uuid, self.definition, self.skill_mapping, self.request_id, self.authorization
+                self.project_uuid, self.definition, self.tool_mapping, self.request_id, self.authorization
             )
 
         assert success is False, f"Should report failure when status code is {status_code}"

--- a/app/api/v1/routers/tests/test_runs.py
+++ b/app/api/v1/routers/tests/test_runs.py
@@ -1,4 +1,4 @@
-"""Tests for skill runs endpoint."""
+"""Tests for tool runs endpoint."""
 
 import io
 import json
@@ -18,7 +18,7 @@ from app.tests.utils import AsyncMock
 # Common test constants
 TEST_CONTENT = b"test content"
 TEST_AGENT_NAME = "test-agent"
-TEST_SKILL_NAME = "test-skill"
+TEST_TOOL_NAME = "test-tool"
 TEST_TOKEN = "Bearer test-token"
 TEST_FUNCTION_NAME = "test-function-name"
 TEST_FUNCTION_ARN = "arn:aws:lambda:us-east-1:123456789012:function:test-function-name"
@@ -55,15 +55,15 @@ def auth_header() -> dict[str, str]:
 
 
 @pytest.fixture
-def run_skill_request_data() -> dict[str, Any]:
-    """Return test data for run_skill_test endpoint."""
+def run_tool_request_data() -> dict[str, Any]:
+    """Return test data for run_tool_test endpoint."""
     agent_definition = {
         "name": TEST_AGENT_NAME,
         "slug": "test-agent-slug",
-        "skills": [
+        "tools": [
             {
-                "name": TEST_SKILL_NAME,
-                "slug": "test-skill-slug",
+                "name": TEST_TOOL_NAME,
+                "slug": "test-tool-slug",
             }
         ],
     }
@@ -79,14 +79,14 @@ def run_skill_request_data() -> dict[str, Any]:
         "project_uuid": str(uuid4()),
         "definition": json.dumps({"agents": {"test-agent-id": agent_definition}}),
         "test_definition": json.dumps(test_definition),
-        "skill_name": TEST_SKILL_NAME,
+        "tool_name": TEST_TOOL_NAME,
         "agent_name": TEST_AGENT_NAME,
-        "skill_credentials": json.dumps(
+        "tool_credentials": json.dumps(
             {
                 "credential-test-key": "test-value",
             }
         ),
-        "skill_globals": json.dumps(
+        "tool_globals": json.dumps(
             {
                 "global-test-key": "test-value",
             }
@@ -107,18 +107,18 @@ def test_log_events() -> list[dict[str, Any]]:
 
 @pytest.fixture
 def post_run_request_factory(
-    client: TestClient, api_path: str, auth_header: dict[str, str], run_skill_request_data: dict[str, Any]
+    client: TestClient, api_path: str, auth_header: dict[str, str], run_tool_request_data: dict[str, Any]
 ) -> Callable[[], Any]:
     """Return a factory function for making POST requests to the runs endpoint."""
 
     def make_post_request() -> Any:
-        # Create files dictionary with the skill file
+        # Create files dictionary with the tool file
         files = {
-            "skill": ("test_skill.zip", io.BytesIO(TEST_CONTENT), "application/zip"),
+            "tool": ("test_tool.zip", io.BytesIO(TEST_CONTENT), "application/zip"),
         }
 
         # Merge the data and files for the multipart request
-        data = {**run_skill_request_data}
+        data = {**run_tool_request_data}
 
         headers = {**auth_header, "X-CLI-Version": settings.CLI_MINIMUM_VERSION}
 
@@ -161,24 +161,24 @@ def parse_streaming_response(response: Any) -> list[dict[str, Any]]:
     return result
 
 
-class TestRunSkillEndpoint:
-    """Tests for the run_skill_test endpoint."""
+class TestRunToolEndpoint:
+    """Tests for the run_tool_test endpoint."""
 
     @pytest.fixture
     def mock_success_dependencies(self, mocker: MockerFixture) -> None:
-        """Mock dependencies for successful run_skill_test."""
-        # Mock process_skill to return a successful result
+        """Mock dependencies for successful run_tool_test."""
+        # Mock process_tool to return a successful result
         mock_process_result = {
-            "message": "Skill processed successfully",
+            "message": "Tool processed successfully",
             "data": {
-                "skill_name": TEST_SKILL_NAME,
+                "tool_name": TEST_TOOL_NAME,
             },
             "success": True,
-            "code": "SKILL_PROCESSED",
+            "code": "TOOL_PROCESSED",
         }
 
         mocker.patch(
-            "app.api.v1.routers.runs.process_skill",
+            "app.api.v1.routers.runs.process_tool",
             new=AsyncMock(return_value=(mock_process_result, io.BytesIO(TEST_CONTENT))),
         )
 
@@ -204,12 +204,12 @@ class TestRunSkillEndpoint:
         # Mock asyncio.sleep to avoid delays in tests
         mocker.patch("asyncio.sleep", new=AsyncMock(return_value=None))
 
-    def test_run_skill_success(
+    def test_run_tool_success(
         self, post_run_request_factory: Callable[[], Any], mock_success_dependencies: None, mock_auth_middleware: None
     ) -> None:
-        """Test successful run_skill_test endpoint."""
+        """Test successful run_tool_test endpoint."""
         # Minimum expected response items
-        min_expected_responses = 4  # initial, skill processed, lambda creating, completion/error
+        min_expected_responses = 4  # initial, tool processed, lambda creating, completion/error
 
         # Execute
         response = post_run_request_factory()
@@ -223,15 +223,15 @@ class TestRunSkillEndpoint:
         # Check for expected response objects
         assert (
             len(response_data) >= min_expected_responses
-        )  # At least initial response, skill processed, lambda creating, completion/error
+        )  # At least initial response, tool processed, lambda creating, completion/error
 
         # Check initial response
         assert response_data[0]["code"] == "PROCESSING_STARTED", "First message should have code=PROCESSING_STARTED"
         assert response_data[0]["success"] is True, "First message should have success=True"
 
-        # Check for skill processed message
-        skill_processed_msgs = [r for r in response_data if r.get("code") == "SKILL_PROCESSED"]
-        assert len(skill_processed_msgs) > 0, "Should include a SKILL_PROCESSED message"
+        # Check for tool processed message
+        tool_processed_msgs = [r for r in response_data if r.get("code") == "TOOL_PROCESSED"]
+        assert len(tool_processed_msgs) > 0, "Should include a TOOL_PROCESSED message"
 
         # Check for lambda creating message
         lambda_creating_msgs = [r for r in response_data if r.get("code") == "LAMBDA_FUNCTION_CREATING"]
@@ -241,18 +241,18 @@ class TestRunSkillEndpoint:
         "test_id, data_fields, files_fields, headers, expected_status, expected_error_code",
         [
             (
-                "missing_skill_file",
+                "missing_tool_file",
                 {
                     "project_uuid": str(uuid4()),
                     "definition": json.dumps({"agents": {}}),
                     "test_definition": json.dumps({"tests": {}}),
-                    "skill_name": TEST_SKILL_NAME,
+                    "tool_name": TEST_TOOL_NAME,
                     "agent_name": TEST_AGENT_NAME,
-                    "skill_credentials": json.dumps({}),
-                    "skill_globals": json.dumps({}),
+                    "tool_credentials": json.dumps({}),
+                    "tool_globals": json.dumps({}),
                     "toolkit_version": "1.0.0",
                 },
-                {},  # No skill file
+                {},  # No tool file
                 None,  # Use default auth header
                 status.HTTP_400_BAD_REQUEST,
                 None,  # No streaming response for 400
@@ -263,14 +263,14 @@ class TestRunSkillEndpoint:
                     "project_uuid": str(uuid4()),
                     "definition": json.dumps({"agents": {}}),
                     "test_definition": json.dumps({"tests": {}}),
-                    "skill_name": TEST_SKILL_NAME,
+                    "tool_name": TEST_TOOL_NAME,
                     "agent_name": TEST_AGENT_NAME,
-                    "skill_credentials": json.dumps({}),
-                    "skill_globals": json.dumps({}),
+                    "tool_credentials": json.dumps({}),
+                    "tool_globals": json.dumps({}),
                     "toolkit_version": "1.0.0",
                 },
                 {
-                    "skill": ("test_skill.zip", io.BytesIO(TEST_CONTENT), "application/zip"),
+                    "tool": ("test_tool.zip", io.BytesIO(TEST_CONTENT), "application/zip"),
                 },
                 {
                     "X-CLI-Version": settings.CLI_MINIMUM_VERSION,
@@ -291,20 +291,20 @@ class TestRunSkillEndpoint:
         expected_error_code: str | None,
         mock_auth_middleware: None,
     ) -> None:
-        """Test validation errors for run_skill_test endpoint."""
+        """Test validation errors for run_tool_test endpoint."""
         # Execute
         response = custom_post_run_request_factory(data_fields, files_fields, headers)
 
         # Assert
         assert response.status_code == expected_status, f"Expected status {expected_status} for {test_id}"
 
-    def test_process_skill_error(
+    def test_process_tool_error(
         self, post_run_request_factory: Callable[[], Any], mocker: MockerFixture, mock_auth_middleware: None
     ) -> None:
-        """Test error handling when process_skill raises an exception."""
+        """Test error handling when process_tool raises an exception."""
         # Setup
-        error_message = "Error processing skill"
-        mocker.patch("app.api.v1.routers.runs.process_skill", new=AsyncMock(side_effect=ValueError(error_message)))
+        error_message = "Error processing tool"
+        mocker.patch("app.api.v1.routers.runs.process_tool", new=AsyncMock(side_effect=ValueError(error_message)))
 
         # Mock AWS clients
         mock_lambda_client = mocker.MagicMock()
@@ -336,17 +336,17 @@ class TestRunSkillEndpoint:
         self, post_run_request_factory: Callable[[], Any], mocker: MockerFixture, mock_auth_middleware: None
     ) -> None:
         """Test error handling when lambda function creation fails."""
-        # Setup - mock process_skill to succeed
+        # Setup - mock process_tool to succeed
         mock_process_result = {
-            "message": "Skill processed successfully",
+            "message": "Tool processed successfully",
             "data": {
-                "skill_name": TEST_SKILL_NAME,
+                "tool_name": TEST_TOOL_NAME,
             },
             "success": True,
-            "code": "SKILL_PROCESSED",
+            "code": "TOOL_PROCESSED",
         }
         mocker.patch(
-            "app.api.v1.routers.runs.process_skill",
+            "app.api.v1.routers.runs.process_tool",
             new=AsyncMock(return_value=(mock_process_result, io.BytesIO(TEST_CONTENT))),
         )
 
@@ -380,17 +380,17 @@ class TestRunSkillEndpoint:
         self, post_run_request_factory: Callable[[], Any], mocker: MockerFixture, mock_auth_middleware: None
     ) -> None:
         """Test error handling when lambda function activation fails."""
-        # Setup - mock process_skill to succeed
+        # Setup - mock process_tool to succeed
         mock_process_result = {
-            "message": "Skill processed successfully",
+            "message": "Tool processed successfully",
             "data": {
-                "skill_name": TEST_SKILL_NAME,
+                "tool_name": TEST_TOOL_NAME,
             },
             "success": True,
-            "code": "SKILL_PROCESSED",
+            "code": "TOOL_PROCESSED",
         }
         mocker.patch(
-            "app.api.v1.routers.runs.process_skill",
+            "app.api.v1.routers.runs.process_tool",
             new=AsyncMock(return_value=(mock_process_result, io.BytesIO(TEST_CONTENT))),
         )
 
@@ -430,17 +430,17 @@ class TestRunSkillEndpoint:
         self, post_run_request_factory: Callable[[], Any], mocker: MockerFixture, mock_auth_middleware: None
     ) -> None:
         """Test error handling when lambda function invocation fails."""
-        # Setup - mock process_skill to succeed
+        # Setup - mock process_tool to succeed
         mock_process_result = {
-            "message": "Skill processed successfully",
+            "message": "Tool processed successfully",
             "data": {
-                "skill_name": TEST_SKILL_NAME,
+                "tool_name": TEST_TOOL_NAME,
             },
             "success": True,
-            "code": "SKILL_PROCESSED",
+            "code": "TOOL_PROCESSED",
         }
         mocker.patch(
-            "app.api.v1.routers.runs.process_skill",
+            "app.api.v1.routers.runs.process_tool",
             new=AsyncMock(return_value=(mock_process_result, io.BytesIO(TEST_CONTENT))),
         )
 
@@ -484,7 +484,7 @@ class TestRunSkillEndpoint:
     ) -> None:
         """Test that resources are cleaned up when an error occurs."""
         mocker.patch(
-            "app.api.v1.routers.runs.process_skill", new=AsyncMock(side_effect=ValueError("Process skill error"))
+            "app.api.v1.routers.runs.process_tool", new=AsyncMock(side_effect=ValueError("Process tool error"))
         )
 
         # When the Lambda client is created early in the code, make lambda_function_name available
@@ -525,7 +525,7 @@ class TestRunSkillEndpoint:
         self,
         post_run_request_factory: Callable[[], Any],
         mocker: MockerFixture,
-        run_skill_request_data: dict[str, Any],
+        run_tool_request_data: dict[str, Any],
         mock_auth_middleware: None,
     ) -> None:
         """Test error handling when agent is not found in definition."""
@@ -541,7 +541,7 @@ class TestRunSkillEndpoint:
         mocker.patch("asyncio.sleep", new=AsyncMock(return_value=None))
 
         # Modify the request data
-        modified_data = run_skill_request_data.copy()
+        modified_data = run_tool_request_data.copy()
         modified_data["definition"] = json.dumps(empty_definition)
 
         # Make the request
@@ -549,7 +549,7 @@ class TestRunSkillEndpoint:
         api_path = f"{settings.API_PREFIX}/v1/runs"
 
         files = {
-            "skill": ("test_skill.zip", io.BytesIO(TEST_CONTENT), "application/zip"),
+            "tool": ("test_tool.zip", io.BytesIO(TEST_CONTENT), "application/zip"),
         }
 
         response = client.post(
@@ -574,21 +574,21 @@ class TestRunSkillEndpoint:
         assert len(error_responses) > 0
         assert f"Could not find agent {TEST_AGENT_NAME}" in str(error_responses[-1])
 
-    def test_skill_not_found_for_agent(
+    def test_tool_not_found_for_agent(
         self,
         post_run_request_factory: Callable[[], Any],
         mocker: MockerFixture,
-        run_skill_request_data: dict[str, Any],
+        run_tool_request_data: dict[str, Any],
         mock_auth_middleware: None,
     ) -> None:
-        """Test error handling when skill is not found for agent."""
-        # Setup - Create a definition with an agent but no skills
-        agent_without_skills = {
+        """Test error handling when tool is not found for agent."""
+        # Setup - Create a definition with an agent but no tools
+        agent_without_tools = {
             "name": TEST_AGENT_NAME,
             "slug": "test-agent-slug",
-            "skills": [],  # Empty skills list
+            "tools": [],  # Empty tools list
         }
-        definition = {"agents": {"test-agent-id": agent_without_skills}}
+        definition = {"agents": {"test-agent-id": agent_without_tools}}
 
         # Setup mocks
         mock_lambda_client = mocker.MagicMock()
@@ -599,7 +599,7 @@ class TestRunSkillEndpoint:
         mocker.patch("asyncio.sleep", new=AsyncMock(return_value=None))
 
         # Modify the request data
-        modified_data = run_skill_request_data.copy()
+        modified_data = run_tool_request_data.copy()
         modified_data["definition"] = json.dumps(definition)
 
         # Make the request
@@ -607,7 +607,7 @@ class TestRunSkillEndpoint:
         api_path = f"{settings.API_PREFIX}/v1/runs"
 
         files = {
-            "skill": ("test_skill.zip", io.BytesIO(TEST_CONTENT), "application/zip"),
+            "tool": ("test_tool.zip", io.BytesIO(TEST_CONTENT), "application/zip"),
         }
 
         response = client.post(
@@ -630,25 +630,25 @@ class TestRunSkillEndpoint:
         # Check for error message
         error_responses = [r for r in response_data if r.get("success") is False]
         assert len(error_responses) > 0
-        assert f"Could not find skill {TEST_SKILL_NAME}" in str(error_responses[-1])
+        assert f"Could not find tool {TEST_TOOL_NAME}" in str(error_responses[-1])
 
-    def test_empty_skill_zip_bytes(
+    def test_empty_tool_zip_bytes(
         self, post_run_request_factory: Callable[[], Any], mocker: MockerFixture, mock_auth_middleware: None
     ) -> None:
-        """Test error handling when skill_zip_bytes is empty after processing."""
-        # Setup - mock process_skill to return None for skill_zip_bytes
+        """Test error handling when tool_zip_bytes is empty after processing."""
+        # Setup - mock process_tool to return None for tool_zip_bytes
         mock_process_result = {
-            "message": "Skill processed successfully",
+            "message": "Tool processed successfully",
             "data": {
-                "skill_name": TEST_SKILL_NAME,
+                "tool_name": TEST_TOOL_NAME,
             },
             "success": True,
-            "code": "SKILL_PROCESSED",
+            "code": "TOOL_PROCESSED",
         }
         mocker.patch(
-            "app.api.v1.routers.runs.process_skill",
+            "app.api.v1.routers.runs.process_tool",
             new=AsyncMock(
-                return_value=(mock_process_result, None)  # Return None for skill_zip_bytes
+                return_value=(mock_process_result, None)  # Return None for tool_zip_bytes
             ),
         )
 
@@ -672,4 +672,4 @@ class TestRunSkillEndpoint:
         # Check for error message
         error_responses = [r for r in response_data if r.get("success") is False]
         assert len(error_responses) > 0
-        assert "Failed to process skill" in str(error_responses[-1])
+        assert "Failed to process tool" in str(error_responses[-1])

--- a/app/clients/nexus_client.py
+++ b/app/clients/nexus_client.py
@@ -14,7 +14,7 @@ class NexusClient:
         self.headers = {"Authorization": user_auth_token}
         self.base_url = settings.NEXUS_BASE_URL
 
-    def push_agents(self, project_uuid: str, agents_definition: dict, skill_files: dict) -> Response:
+    def push_agents(self, project_uuid: str, agents_definition: dict, tool_files: dict) -> Response:
         url = f"{self.base_url}/api/agents/push"
 
         data = {
@@ -22,4 +22,4 @@ class NexusClient:
             "agents": json.dumps(agents_definition),
         }
 
-        return requests.post(url, headers=self.headers, data=data, files=skill_files)
+        return requests.post(url, headers=self.headers, data=data, files=tool_files)

--- a/app/clients/tests/test_nexus_client.py
+++ b/app/clients/tests/test_nexus_client.py
@@ -38,14 +38,14 @@ def agents_definition() -> dict:
             "test-agent": {
                 "name": "Test Agent",
                 "description": "Test Agent Description",
-                "skills": [
+                "tools": [
                     {
-                        "name": "test-skill",
-                        "description": "Test Skill Description",
-                        "slug": "test-skill",
+                        "name": "test-tool",
+                        "description": "Test Tool Description",
+                        "slug": "test-tool",
                         "source": {
-                            "path": "test_skill.zip",
-                            "entrypoint": "main.TestSkill",
+                            "path": "test_tool.zip",
+                            "entrypoint": "main.TestTool",
                         },
                         "parameters": [
                             {
@@ -64,9 +64,9 @@ def agents_definition() -> dict:
 
 
 @pytest.fixture
-def skill_files() -> dict:
-    """Return sample skill files."""
-    return {"skill-test-skill": ("test_skill.zip", b"test skill content", "application/zip")}
+def tool_files() -> dict:
+    """Return sample tool files."""
+    return {"tool-test-tool": ("test_tool.zip", b"test tool content", "application/zip")}
 
 
 class TestNexusClient:
@@ -85,7 +85,7 @@ class TestNexusClient:
         nexus_client: NexusClient,
         project_uuid: str,
         agents_definition: dict,
-        skill_files: dict,
+        tool_files: dict,
     ) -> None:
         """Test the push_agents method."""
         # Setup mocked response
@@ -93,7 +93,7 @@ class TestNexusClient:
         requests_mock.post(expected_url, json={"success": True}, status_code=status.HTTP_200_OK)
 
         # Call the method
-        response = nexus_client.push_agents(project_uuid, agents_definition, skill_files)
+        response = nexus_client.push_agents(project_uuid, agents_definition, tool_files)
 
         # Assertions
         assert response.status_code == status.HTTP_200_OK
@@ -113,7 +113,7 @@ class TestNexusClient:
         assert json.dumps(agents_definition) in last_request.text
 
         # Verify files were present in the request
-        assert "skill-test-skill" in last_request.text
+        assert "tool-test-tool" in last_request.text
 
     def test_push_agents_error_response(  # noqa: PLR0913
         self,
@@ -121,7 +121,7 @@ class TestNexusClient:
         nexus_client: NexusClient,
         project_uuid: str,
         agents_definition: dict,
-        skill_files: dict,
+        tool_files: dict,
     ) -> None:
         """Test push_agents method when receiving an error response."""
         # Setup mocked response
@@ -129,7 +129,7 @@ class TestNexusClient:
         requests_mock.post(expected_url, json={"error": "Bad request"}, status_code=status.HTTP_400_BAD_REQUEST)
 
         # Call the method
-        response = nexus_client.push_agents(project_uuid, agents_definition, skill_files)
+        response = nexus_client.push_agents(project_uuid, agents_definition, tool_files)
 
         # Assertions
         assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/app/services/skill/__init__.py
+++ b/app/services/skill/__init__.py
@@ -1,8 +1,0 @@
-"""
-Skill packaging and validation services.
-"""
-
-from app.services.skill.packager import create_skill_zip
-from app.services.skill.validator import validate_requirements_file
-
-__all__ = ["create_skill_zip", "validate_requirements_file"]

--- a/app/services/skill/tests/__init__.py
+++ b/app/services/skill/tests/__init__.py
@@ -1,3 +1,0 @@
-"""
-Unit tests for the skill service.
-"""

--- a/app/services/tool/__init__.py
+++ b/app/services/tool/__init__.py
@@ -1,0 +1,8 @@
+"""
+Tool packaging and validation services.
+"""
+
+from app.services.tool.packager import create_tool_zip
+from app.services.tool.validator import validate_requirements_file
+
+__all__ = ["create_tool_zip", "validate_requirements_file"]

--- a/app/services/tool/templates/lambda_function.py.template
+++ b/app/services/tool/templates/lambda_function.py.template
@@ -4,7 +4,7 @@ import sentry_sdk
 from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
 
 from weni.context import Context
-from skill.{module} import {class_name}
+from tool.{module} import {class_name}
 
 
 sentry_sdk.init(

--- a/app/services/tool/templates/lambda_function.py.template
+++ b/app/services/tool/templates/lambda_function.py.template
@@ -11,7 +11,7 @@ sentry_sdk.init(
 import json
 
 from weni.context import Context
-from skill.{module} import {class_name}
+from tool.{module} import {class_name}
 
 
 def lambda_handler(event, context):

--- a/app/services/tool/tests/__init__.py
+++ b/app/services/tool/tests/__init__.py
@@ -1,0 +1,3 @@
+"""
+Unit tests for the tool service.
+"""

--- a/app/services/tool/tests/test_packager.py
+++ b/app/services/tool/tests/test_packager.py
@@ -1,5 +1,5 @@
 """
-Tests for the skill package packager.
+Tests for the tool package packager.
 """
 
 import io
@@ -16,11 +16,11 @@ from uuid import uuid4
 import pytest
 from pytest_mock import MockerFixture
 
-from app.services.skill.packager import (
+from app.services.tool.packager import (
     SUBPROCESS_TIMEOUT_SECONDS,
     Package,
     build_lambda_function_file,
-    create_skill_zip,
+    create_tool_zip,
     install_dependencies,
     install_packages,
 )
@@ -28,8 +28,8 @@ from app.services.skill.packager import (
 # Common test constants
 TEST_CONTENT = b"test content"
 TEST_AGENT = "test-agent"
-TEST_SKILL = "test-skill"
-TEST_SKILL_KEY = f"{TEST_AGENT}:{TEST_SKILL}"
+TEST_TOOL = "test-tool"
+TEST_TOOL_KEY = f"{TEST_AGENT}:{TEST_TOOL}"
 TEST_TOKEN = "Bearer test-token"
 
 
@@ -53,19 +53,19 @@ def requirements_file() -> Generator[Path, None, None]:
 
 
 @pytest.fixture
-def skill_folder_zip() -> BytesIO:
-    """Creates a sample skill folder zip for testing."""
+def tool_folder_zip() -> BytesIO:
+    """Creates a sample tool folder zip for testing."""
     buffer = BytesIO()
     with zipfile.ZipFile(buffer, "w") as zip_file:
         # Add a sample Python file
         zip_file.writestr(
-            "skill.py",
-            "class SkillHandler:\n    def handle(self, event, context):\n        return {'message': 'Hello'}",
+            "tool.py",
+            "class ToolHandler:\n    def handle(self, event, context):\n        return {'message': 'Hello'}",
         )
         # Add a requirements.txt file
         zip_file.writestr("requirements.txt", "requests==2.31.0\npydantic>=2.0.0\n")
         # Add a README file
-        zip_file.writestr("README.md", "# Sample Skill\nThis is a sample skill.")
+        zip_file.writestr("README.md", "# Sample Tool\nThis is a sample tool.")
 
     buffer.seek(0)
     return buffer
@@ -158,7 +158,7 @@ class TestInstallDependencies:
         mocker.patch("subprocess.run", mock_run)
 
         # Call the function
-        install_dependencies(temp_dir, requirements_file, "test-skill", "1.0.0")
+        install_dependencies(temp_dir, requirements_file, "test-tool", "1.0.0")
 
         # Verify subprocess.run was called with correct arguments - now called once for regular dependencies
         mock_run.assert_called_once()
@@ -180,7 +180,7 @@ class TestInstallDependencies:
 
         # Verify function raises ValueError
         with pytest.raises(ValueError) as exc_info:
-            install_dependencies(temp_dir, requirements_file, "test-skill", "1.0.0")
+            install_dependencies(temp_dir, requirements_file, "test-tool", "1.0.0")
         assert "Failed to install requirements" in str(exc_info.value), "Error message should be descriptive"
         assert "Could not find package" in str(exc_info.value), "Should include the subprocess error"
 
@@ -193,7 +193,7 @@ class TestInstallDependencies:
 
         # Verify function raises ValueError
         with pytest.raises(ValueError) as exc_info:
-            install_dependencies(temp_dir, requirements_file, "test-skill", "1.0.0")
+            install_dependencies(temp_dir, requirements_file, "test-tool", "1.0.0")
         assert "Timeout installing requirements" in str(exc_info.value), "Error should mention timeout"
         assert str(SUBPROCESS_TIMEOUT_SECONDS) in str(exc_info.value), "Should include timeout duration"
 
@@ -203,8 +203,8 @@ class TestBuildLambdaFunctionFile:
 
     def test_successful_template_creation(self) -> None:
         """Test successful Lambda function template creation."""
-        module_name = "skill_module"
-        class_name = "SkillHandler"
+        module_name = "tool_module"
+        class_name = "ToolHandler"
 
         # Call the function
         result = build_lambda_function_file(module_name, class_name)
@@ -212,9 +212,9 @@ class TestBuildLambdaFunctionFile:
         # Verify specific content is correctly substituted
         assert "import json" in result
         assert "from weni.context import Context" in result
-        assert "from skill.skill_module import SkillHandler" in result
+        assert "from tool.tool_module import ToolHandler" in result
         assert "def lambda_handler(event, context):" in result
-        assert "result, format = SkillHandler(context)" in result
+        assert "result, format = ToolHandler(context)" in result
         assert "dummy_function_response = {'response': action_response, 'messageVersion': '1.0'}" in result
         assert "sentry_sdk.init(" in result
 
@@ -222,7 +222,7 @@ class TestBuildLambdaFunctionFile:
         """Test template variable substitution with different values."""
         result = build_lambda_function_file("custom_module", "CustomClass")
 
-        assert "from skill.custom_module import CustomClass" in result
+        assert "from tool.custom_module import CustomClass" in result
         assert "result, format = CustomClass(context)" in result
         # Ensure other parts of the template are intact
         assert "json.loads(session_attributes.get('credentials'))" in result
@@ -237,39 +237,39 @@ class TestBuildLambdaFunctionFile:
             build_lambda_function_file("module", "Class")
 
 
-class TestCreateSkillZip:
-    """Tests for the create_skill_zip function."""
+class TestCreateToolZip:
+    """Tests for the create_tool_zip function."""
 
     @pytest.fixture
-    def skill_folder_zip(self) -> BytesIO:
-        """Create a test zip file containing a skill."""
+    def tool_folder_zip(self) -> BytesIO:
+        """Create a test zip file containing a tool."""
         buffer = BytesIO()
         with zipfile.ZipFile(buffer, "w") as zip_file:
-            zip_file.writestr("skill.py", "class SkillHandler: pass")
+            zip_file.writestr("tool.py", "class ToolHandler: pass")
             zip_file.writestr("requirements.txt", "pytest==7.3.1\nrequests==2.31.0\n")
         buffer.seek(0)
         return buffer
 
-    def test_successful_zip_creation(self, skill_folder_zip: BytesIO, mocker: MockerFixture) -> None:
-        """Test successful creation of skill zip."""
+    def test_successful_zip_creation(self, tool_folder_zip: BytesIO, mocker: MockerFixture) -> None:
+        """Test successful creation of tool zip."""
         # Mock validation to return success
-        mocker.patch("app.services.skill.packager.validate_requirements_file", return_value=(True, ""))
+        mocker.patch("app.services.tool.packager.validate_requirements_file", return_value=(True, ""))
 
         # Mock toolkit installation
-        mock_install_packages = mocker.patch("app.services.skill.packager.install_packages")
+        mock_install_packages = mocker.patch("app.services.tool.packager.install_packages")
 
         # Mock dependencies installation
-        mock_install_dependencies = mocker.patch("app.services.skill.packager.install_dependencies")
+        mock_install_dependencies = mocker.patch("app.services.tool.packager.install_dependencies")
 
         # Mock lambda function file creation
         mocker.patch(
-            "app.services.skill.packager.build_lambda_function_file",
+            "app.services.tool.packager.build_lambda_function_file",
             return_value="def lambda_handler(event, context): pass",
         )
 
         # Call the function
-        result = create_skill_zip(
-            skill_folder_zip.getvalue(), "test-skill", "project-123", "skill_module", "SkillHandler", "1.0.0"
+        result = create_tool_zip(
+            tool_folder_zip.getvalue(), "test-tool", "project-123", "tool_module", "ToolHandler", "1.0.0"
         )
 
         # Verify result
@@ -284,52 +284,52 @@ class TestCreateSkillZip:
         with zipfile.ZipFile(result) as zip_file:
             assert "lambda_function.py" in zip_file.namelist(), "Should include lambda function"
 
-    def test_invalid_requirements(self, skill_folder_zip: BytesIO, mocker: MockerFixture) -> None:
+    def test_invalid_requirements(self, tool_folder_zip: BytesIO, mocker: MockerFixture) -> None:
         """Test zip creation with invalid requirements."""
         # Mock toolkit installation
-        mocker.patch("app.services.skill.packager.install_packages")
+        mocker.patch("app.services.tool.packager.install_packages")
 
         # Mock validation to return failure
         mocker.patch(
-            "app.services.skill.packager.validate_requirements_file", return_value=(False, "Invalid requirements file")
+            "app.services.tool.packager.validate_requirements_file", return_value=(False, "Invalid requirements file")
         )
 
         # Verify function raises ValueError
         with pytest.raises(ValueError) as exc_info:
-            create_skill_zip(
-                skill_folder_zip.getvalue(), "test-skill", "project-123", "skill_module", "SkillHandler", "1.0.0"
+            create_tool_zip(
+                tool_folder_zip.getvalue(), "test-tool", "project-123", "tool_module", "ToolHandler", "1.0.0"
             )
         assert "Invalid requirements file" in str(exc_info.value), "Should include validation message"
 
-    def test_installation_error(self, skill_folder_zip: BytesIO, mocker: MockerFixture) -> None:
+    def test_installation_error(self, tool_folder_zip: BytesIO, mocker: MockerFixture) -> None:
         """Test zip creation with dependency installation error."""
         # Mock toolkit installation
-        mocker.patch("app.services.skill.packager.install_packages")
+        mocker.patch("app.services.tool.packager.install_packages")
 
         # Mock validation to return success
-        mocker.patch("app.services.skill.packager.validate_requirements_file", return_value=(True, ""))
+        mocker.patch("app.services.tool.packager.validate_requirements_file", return_value=(True, ""))
 
         # Mock install_dependencies to raise ValueError
-        mocker.patch("app.services.skill.packager.install_dependencies", side_effect=ValueError("Installation failed"))
+        mocker.patch("app.services.tool.packager.install_dependencies", side_effect=ValueError("Installation failed"))
 
         # Verify function raises ValueError
         with pytest.raises(ValueError) as exc_info:
-            create_skill_zip(
-                skill_folder_zip.getvalue(), "test-skill", "project-123", "skill_module", "SkillHandler", "1.0.0"
+            create_tool_zip(
+                tool_folder_zip.getvalue(), "test-tool", "project-123", "tool_module", "ToolHandler", "1.0.0"
             )
         assert "Installation failed" in str(exc_info.value), "Should propagate the error message"
 
-    def test_toolkit_installation_error(self, skill_folder_zip: BytesIO, mocker: MockerFixture) -> None:
+    def test_toolkit_installation_error(self, tool_folder_zip: BytesIO, mocker: MockerFixture) -> None:
         """Test zip creation with toolkit installation error."""
         # Mock install_packages to raise ValueError
         mocker.patch(
-            "app.services.skill.packager.install_packages", side_effect=ValueError("Toolkit installation failed")
+            "app.services.tool.packager.install_packages", side_effect=ValueError("Toolkit installation failed")
         )
 
         # Verify function raises ValueError
         with pytest.raises(ValueError) as exc_info:
-            create_skill_zip(
-                skill_folder_zip.getvalue(), "test-skill", "project-123", "skill_module", "SkillHandler", "1.0.0"
+            create_tool_zip(
+                tool_folder_zip.getvalue(), "test-tool", "project-123", "tool_module", "ToolHandler", "1.0.0"
             )
         assert "Toolkit installation failed" in str(exc_info.value), "Should propagate the toolkit error"
 
@@ -340,32 +340,32 @@ class TestCreateSkillZip:
 
         # Verify function raises zipfile.BadZipFile
         with pytest.raises(zipfile.BadZipFile):
-            create_skill_zip(invalid_content, "test-skill", "project-123", "skill_module", "SkillHandler", "1.0.0")
+            create_tool_zip(invalid_content, "test-tool", "project-123", "tool_module", "ToolHandler", "1.0.0")
 
     def test_no_requirements_file(self, mocker: MockerFixture) -> None:
         """Test zip creation with no requirements.txt file."""
         # Create a zip without requirements.txt
         buffer = BytesIO()
         with zipfile.ZipFile(buffer, "w") as zip_file:
-            zip_file.writestr("skill.py", "class SkillHandler: pass")
+            zip_file.writestr("tool.py", "class ToolHandler: pass")
 
         # Mock toolkit installation
-        mock_install_packages = mocker.patch("app.services.skill.packager.install_packages")
+        mock_install_packages = mocker.patch("app.services.tool.packager.install_packages")
 
         # Mock dependencies installation - should NOT be called
-        mock_install_dependencies = mocker.patch("app.services.skill.packager.install_dependencies")
+        mock_install_dependencies = mocker.patch("app.services.tool.packager.install_dependencies")
 
         # Mock lambda function file creation
         mocker.patch(
-            "app.services.skill.packager.build_lambda_function_file",
+            "app.services.tool.packager.build_lambda_function_file",
             return_value="def lambda_handler(event, context): pass",
         )
 
         buffer.seek(0)
 
         # Call the function with toolkit_version parameter
-        result = create_skill_zip(
-            buffer.getvalue(), "test-skill", "project-123", "skill_module", "SkillHandler", "1.0.0"
+        result = create_tool_zip(
+            buffer.getvalue(), "test-tool", "project-123", "tool_module", "ToolHandler", "1.0.0"
         )
 
         # Verify result
@@ -382,44 +382,44 @@ class TestCreateSkillZip:
     def test_cleanup_on_exception(self, mocker: MockerFixture) -> None:
         """Test that temporary directory is cleaned up on exception."""
         # Mock tempfile.mkdtemp to return a fixed path
-        temp_dir_path = "/tmp/test_skill_dir"
-        mocker.patch("app.services.skill.packager.tempfile.mkdtemp", return_value=temp_dir_path)
+        temp_dir_path = "/tmp/test_tool_dir"
+        mocker.patch("app.services.tool.packager.tempfile.mkdtemp", return_value=temp_dir_path)
 
         # Mock Path.exists to return True when checking the temp directory
-        mocker.patch("app.services.skill.packager.Path.exists", return_value=True)
+        mocker.patch("app.services.tool.packager.Path.exists", return_value=True)
 
         # Mock shutil.rmtree to verify it's called
         rmtree_mock = mocker.Mock()
-        mocker.patch("app.services.skill.packager.shutil.rmtree", rmtree_mock)
+        mocker.patch("app.services.tool.packager.shutil.rmtree", rmtree_mock)
 
         # Create invalid zip content to force an exception
         invalid_content = b"not a valid zip file"
 
         # Call the function and catch the exception
         with pytest.raises(zipfile.BadZipFile):
-            create_skill_zip(invalid_content, "test-skill", "project-123", "skill_module", "SkillHandler", "1.0.0")
+            create_tool_zip(invalid_content, "test-tool", "project-123", "tool_module", "ToolHandler", "1.0.0")
 
         # Verify cleanup was attempted (now includes ignore_errors=True)
         rmtree_mock.assert_called_once_with(temp_dir_path, ignore_errors=True), "Should clean up temp directory"
 
 
-class TestProcessSkill:
-    """Tests for process_skill function."""
+class TestProcessTool:
+    """Tests for process_tool function."""
 
     # Common test data
     folder_zip: ClassVar[bytes] = b"test zip content"
-    key: ClassVar[str] = TEST_SKILL_KEY
+    key: ClassVar[str] = TEST_TOOL_KEY
     project_uuid: ClassVar[str] = str(uuid4())
     agent_name: ClassVar[str] = TEST_AGENT
-    skill_name: ClassVar[str] = TEST_SKILL
-    skill_definition: ClassVar[dict[str, Any]] = {
+    tool_name: ClassVar[str] = TEST_TOOL
+    tool_definition: ClassVar[dict[str, Any]] = {
         "agents": {
             TEST_AGENT: {
                 "slug": TEST_AGENT,
-                "skills": [
+                "tools": [
                     {
-                        "slug": TEST_SKILL,
-                        "source": {"entrypoint": "main.TestSkill"},
+                        "slug": TEST_TOOL,
+                        "source": {"entrypoint": "main.TestTool"},
                     }
                 ],
             }
@@ -431,24 +431,24 @@ class TestProcessSkill:
     toolkit_version: ClassVar[str] = "1.0.0"  # Add default toolkit version
 
     def test_success(self) -> None:
-        """Test successful processing of a skill."""
+        """Test successful processing of a tool."""
         import asyncio
 
-        from app.services.skill.packager import process_skill
+        from app.services.tool.packager import process_tool
 
         with pytest.MonkeyPatch().context() as mp:
             mp.setattr(
-                "app.services.skill.packager.create_skill_zip", lambda *args, **kwargs: io.BytesIO(b"packaged content")
+                "app.services.tool.packager.create_tool_zip", lambda *args, **kwargs: io.BytesIO(b"packaged content")
             )
 
-            response, skill_zip = asyncio.run(
-                process_skill(
+            response, tool_zip = asyncio.run(
+                process_tool(
                     self.folder_zip,
                     self.key,
                     self.project_uuid,
                     self.agent_name,
-                    self.skill_name,
-                    self.skill_definition,
+                    self.tool_name,
+                    self.tool_definition,
                     self.processed_count,
                     self.total_count,
                     self.toolkit_version,  # Add toolkit version parameter
@@ -456,28 +456,28 @@ class TestProcessSkill:
             )
 
         assert response["success"] is True, "Should report success"
-        assert skill_zip is not None, "Should return skill zip"
+        assert tool_zip is not None, "Should return tool zip"
         assert response["data"] is not None, "Response should include data"
-        assert response["data"]["skill_name"] == self.skill_name, "Should include skill name"
+        assert response["data"]["tool_name"] == self.tool_name, "Should include tool name"
         assert response["progress"] == self.expected_progress, f"Progress should be {self.expected_progress}"
 
     def test_missing_agent_in_definition(self) -> None:
         """Test handling of missing agent in definition."""
         import asyncio
 
-        from app.services.skill.packager import process_skill
+        from app.services.tool.packager import process_tool
 
         # Use a non-existent agent name
         missing_agent = "non-existent-agent"
 
-        response, skill_zip = asyncio.run(
-            process_skill(
+        response, tool_zip = asyncio.run(
+            process_tool(
                 self.folder_zip,
-                f"{missing_agent}:{self.skill_name}",
+                f"{missing_agent}:{self.tool_name}",
                 self.project_uuid,
                 missing_agent,  # Use the missing agent name
-                self.skill_name,
-                self.skill_definition,  # Definition only contains TEST_AGENT
+                self.tool_name,
+                self.tool_definition,  # Definition only contains TEST_AGENT
                 self.processed_count,
                 self.total_count,
                 self.toolkit_version,  # Add toolkit version parameter
@@ -485,40 +485,40 @@ class TestProcessSkill:
         )
 
         assert response["success"] is False, "Should report failure"
-        assert skill_zip is None, "Should not return skill zip"
+        assert tool_zip is None, "Should not return tool zip"
         assert response["data"] is not None, "Response should include data"
         assert "Could not find agent" in response["data"]["error"], "Error should mention missing agent"
         assert missing_agent in response["data"]["error"], "Error should include the missing agent name"
 
     @pytest.mark.parametrize(
-        "scenario, key, skill_name, expected_error",
+        "scenario, key, tool_name, expected_error",
         [
-            ("missing_skill", "test-agent:missing-skill", "missing-skill", "Could not find skill"),
-            ("exception", TEST_SKILL_KEY, TEST_SKILL, "Zip creation error"),
+            ("missing_tool", "test-agent:missing-tool", "missing-tool", "Could not find tool"),
+            ("exception", TEST_TOOL_KEY, TEST_TOOL, "Zip creation error"),
         ],
     )
-    def test_error_scenarios(self, scenario: str, key: str, skill_name: str, expected_error: str) -> None:
-        """Test various error scenarios in skill processing."""
+    def test_error_scenarios(self, scenario: str, key: str, tool_name: str, expected_error: str) -> None:
+        """Test various error scenarios in tool processing."""
         import asyncio
 
-        from app.api.v1.routers.agents import process_skill
+        from app.api.v1.routers.agents import process_tool
 
         with pytest.MonkeyPatch().context() as mp:
             if scenario == "exception":
                 # Cause an exception
                 mp.setattr(
-                    "app.services.skill.packager.create_skill_zip",
+                    "app.services.tool.packager.create_tool_zip",
                     lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("Zip creation error")),
                 )
 
-            response, skill_zip = asyncio.run(
-                process_skill(
+            response, tool_zip = asyncio.run(
+                process_tool(
                     self.folder_zip,
                     key,
                     self.project_uuid,
                     self.agent_name,
-                    skill_name,
-                    self.skill_definition,
+                    tool_name,
+                    self.tool_definition,
                     self.processed_count,
                     self.total_count,
                     self.toolkit_version,  # Add toolkit version parameter
@@ -528,4 +528,4 @@ class TestProcessSkill:
         assert response["success"] is False, "Should report failure"
         assert response["data"] is not None, "Response should include data"
         assert expected_error in response["data"]["error"], f"Should include '{expected_error}' in error message"
-        assert skill_zip is None, "Should not return skill zip"
+        assert tool_zip is None, "Should not return tool zip"

--- a/app/services/tool/tests/test_validator.py
+++ b/app/services/tool/tests/test_validator.py
@@ -1,5 +1,5 @@
 """
-Tests for the skill package validator.
+Tests for the tool package validator.
 """
 
 import os
@@ -10,7 +10,7 @@ from tempfile import NamedTemporaryFile
 import pytest
 from pytest_mock import MockerFixture
 
-from app.services.skill.validator import (
+from app.services.tool.validator import (
     DANGEROUS_PATTERNS,
     MAX_FILE_SIZE_MB,
     MAX_REQUIREMENTS_COUNT,
@@ -232,7 +232,7 @@ class TestValidateRequirementsFile:
 
         # Mock _check_file_size to return a failure
         mocker.patch(
-            "app.services.skill.validator._check_file_size", return_value=(False, "File too large mock message")
+            "app.services.tool.validator._check_file_size", return_value=(False, "File too large mock message")
         )
 
         result, message = validate_requirements_file(str(temp_requirements_file))
@@ -247,7 +247,7 @@ class TestValidateRequirementsFile:
 
         # Mock _check_requirements_count to return a failure
         mocker.patch(
-            "app.services.skill.validator._check_requirements_count",
+            "app.services.tool.validator._check_requirements_count",
             return_value=(False, "Too many requirements mock message"),
         )
 

--- a/app/services/tool/validator.py
+++ b/app/services/tool/validator.py
@@ -1,5 +1,5 @@
 """
-Validation utilities for skill packages.
+Validation utilities for tool packages.
 """
 
 from pathlib import Path


### PR DESCRIPTION
- This refactors the codebase to replace references to "skill" with "tool" across various modules, including models, routers, and services. 
- The changes include renaming classes, updating function parameters, and modifying logging messages to reflect the new terminology.
- Additionally, the skill packaging service has been replaced with a tool packaging service, ensuring consistency throughout the application.
- This refactor enhances clarity and aligns the code with the new tool-focused architecture.