### PR TITLE
refactor: Rename AWS_REGION to AWS_REGION_NAME for consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2025-05-07
+
+### Added
+- Feat: add AWS region name to config
+
 ## [1.4.0] - 2025-05-06
 
 ### Added

--- a/app/clients/aws/lambda_client.py
+++ b/app/clients/aws/lambda_client.py
@@ -22,7 +22,7 @@ class LambdaFunction(BaseModel):
 
 class AWSLambdaClient:
     def __init__(self) -> None:
-        self.client = boto3.client("lambda", region_name=settings.AWS_REGION)
+        self.client = boto3.client("lambda", region_name=settings.AWS_REGION_NAME)
 
     def get_function(self, function_arn: str) -> LambdaFunction:
         """

--- a/app/clients/aws/logs_client.py
+++ b/app/clients/aws/logs_client.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 class AWSLogsClient:
     def __init__(self) -> None:
-        self.client = boto3.client("logs", region_name=settings.AWS_REGION)
+        self.client = boto3.client("logs", region_name=settings.AWS_REGION_NAME)
 
     # Convert a datetime to milliseconds
     # preserving the timezone or using UTC+0 if no timezone is present

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -40,7 +40,7 @@ class Settings(BaseSettings):
     # AWS settings
     AGENT_RESOURCE_ROLE_ARN: str = ""
     AGENT_LOG_GROUP: str = ""
-    AWS_REGION: str = "us-east-1"
+    AWS_REGION_NAME: str = "us-east-1"
 
     # Sentry settings
     SENTRY_DSN: str = ""


### PR DESCRIPTION
- Updated AWSLambdaClient and AWSLogsClient to use AWS_REGION_NAME instead of AWS_REGION.
- Modified the Settings class to reflect the new configuration variable name.