### PR TITLE
Add Sentry APM

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -51,12 +51,13 @@ class Settings(BaseSettings):
     # Sentry settings
     SENTRY_DSN: str = ""
     FUNCTION_SENTRY_DSN: str = ""
+    SENTRY_ENVIRONMENT: str | None = None
 
     @field_validator("ENVIRONMENT")
     @classmethod
     def validate_environment(cls, value: str) -> str:  # pragma: no cover
         """Validate environment setting."""
-        allowed_environments = ["development", "testing", "production"]
+        allowed_environments = ["development", "testing", "staging", "production"]
         if value.lower() not in allowed_environments:
             raise ValueError(f"Environment must be one of {allowed_environments}")
         return value.lower()

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -52,6 +52,10 @@ class Settings(BaseSettings):
     SENTRY_DSN: str = ""
     FUNCTION_SENTRY_DSN: str = ""
     SENTRY_ENVIRONMENT: str | None = None
+    SENTRY_TRACES_SAMPLE_RATE: float = 1.0
+    SENTRY_PROFILES_SAMPLE_RATE: float = 1.0
+    SENTRY_DEBUG: bool = False
+    SENTRY_RELEASE: str | None = None
 
     @field_validator("ENVIRONMENT")
     @classmethod

--- a/app/main.py
+++ b/app/main.py
@@ -4,10 +4,12 @@ Main FastAPI application.
 
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+import logging
 
 import sentry_sdk
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 from sentry_sdk.integrations.fastapi import FastApiIntegration
 from sentry_sdk.integrations.starlette import StarletteIntegration
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -16,23 +18,39 @@ from app.api.v1.middlewares import AuthorizationMiddleware, VersionCheckMiddlewa
 from app.api.v1.routes import router as api_v1_router
 from app.core.config import settings
 
-sentry_sdk.init(
-    dsn=settings.SENTRY_DSN,
-    environment=settings.SENTRY_ENVIRONMENT or settings.ENVIRONMENT,
-    traces_sample_rate=1.0,
-    profiles_sample_rate=1.0,
-    send_default_pii=True,
-    integrations=[
-        StarletteIntegration(
-            transaction_style="endpoint",
-            failed_request_status_codes={*range(401, 599)},
-        ),
-        FastApiIntegration(
-            transaction_style="endpoint",
-            failed_request_status_codes={*range(401, 599)},
-        ),
-    ],
-)
+logger = logging.getLogger(__name__)
+
+SENTRY_ENABLED = bool(settings.SENTRY_DSN)
+
+if SENTRY_ENABLED:
+    logger.info(
+        "Sentry enabled | environment=%s | traces_sample_rate=%s | profiles_sample_rate=%s | debug=%s",
+        settings.SENTRY_ENVIRONMENT or settings.ENVIRONMENT,
+        settings.SENTRY_TRACES_SAMPLE_RATE,
+        settings.SENTRY_PROFILES_SAMPLE_RATE,
+        settings.SENTRY_DEBUG,
+    )
+    sentry_sdk.init(
+        dsn=settings.SENTRY_DSN,
+        environment=settings.SENTRY_ENVIRONMENT or settings.ENVIRONMENT,
+        release=settings.SENTRY_RELEASE,
+        traces_sample_rate=settings.SENTRY_TRACES_SAMPLE_RATE,
+        profiles_sample_rate=settings.SENTRY_PROFILES_SAMPLE_RATE,
+        send_default_pii=True,
+        debug=settings.SENTRY_DEBUG,
+        integrations=[
+            StarletteIntegration(
+                transaction_style="endpoint",
+                failed_request_status_codes={*range(401, 599)},
+            ),
+            FastApiIntegration(
+                transaction_style="endpoint",
+                failed_request_status_codes={*range(401, 599)},
+            ),
+        ],
+    )
+else:
+    logger.info("Sentry disabled (empty SENTRY_DSN)")
 
 
 @asynccontextmanager
@@ -57,6 +75,10 @@ def create_application() -> FastAPI:
         docs_url=settings.DOCS_URL,
         lifespan=lifespan,
     )
+
+    if SENTRY_ENABLED:
+        # Ensure Sentry wraps the ASGI app so requests become transactions in APM.
+        app.add_middleware(SentryAsgiMiddleware)
 
     # Configure CORS to allow requests from any origin
     app.add_middleware(

--- a/app/main.py
+++ b/app/main.py
@@ -2,9 +2,9 @@
 Main FastAPI application.
 """
 
+import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
-import logging
 
 import sentry_sdk
 from fastapi import FastAPI

--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,7 @@ Main FastAPI application.
 import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+from typing import Any, cast
 
 import sentry_sdk
 from fastapi import FastAPI
@@ -78,7 +79,8 @@ def create_application() -> FastAPI:
 
     if SENTRY_ENABLED:
         # Ensure Sentry wraps the ASGI app so requests become transactions in APM.
-        app.add_middleware(SentryAsgiMiddleware)
+        # sentry-sdk's type hints don't match Starlette's middleware protocol perfectly; runtime is OK.
+        app.add_middleware(cast(Any, SentryAsgiMiddleware))
 
     # Configure CORS to allow requests from any origin
     app.add_middleware(

--- a/app/main.py
+++ b/app/main.py
@@ -18,7 +18,9 @@ from app.core.config import settings
 
 sentry_sdk.init(
     dsn=settings.SENTRY_DSN,
+    environment=settings.SENTRY_ENVIRONMENT or settings.ENVIRONMENT,
     traces_sample_rate=1.0,
+    profiles_sample_rate=1.0,
     send_default_pii=True,
     integrations=[
         StarletteIntegration(

--- a/app/services/agents/active/templates/lambda_function.py.template
+++ b/app/services/agents/active/templates/lambda_function.py.template
@@ -3,8 +3,10 @@ from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
 
 sentry_sdk.init(
     dsn="{sentry_dsn}",
+    environment="{sentry_environment}",
     integrations=[AwsLambdaIntegration()],
     traces_sample_rate=1.0,
+    profiles_sample_rate=1.0,
 )
 
 

--- a/app/services/package/package.py
+++ b/app/services/package/package.py
@@ -9,6 +9,7 @@ from app.core.config import settings
 SUBPROCESS_TIMEOUT_SECONDS = 120
 logger = logging.getLogger(__name__)
 
+
 @dataclass
 class Package:
     name: str
@@ -21,7 +22,6 @@ class Package:
 
 
 class Packager:
-
     def __init__(self, package_dir: Path):
         self.package_dir = package_dir
 
@@ -53,7 +53,6 @@ class Packager:
         except subprocess.TimeoutExpired as e:
             logger.error(f"Timeout installing toolkit: {e}")
             raise ValueError(f"Timeout installing toolkit (>{SUBPROCESS_TIMEOUT_SECONDS}s)") from e
-
 
     def install_dependencies(self, requirements_path: Path, tool_key: str) -> None:
         """
@@ -116,6 +115,9 @@ class Packager:
             template_content = template_content.replace("{{" + f"{key}" + "}}", "{" + f"{key}" + "}")
 
         template_content = template_content.replace("{{sentry_dsn}}", settings.FUNCTION_SENTRY_DSN)
+        template_content = template_content.replace(
+            "{{sentry_environment}}", settings.SENTRY_ENVIRONMENT or settings.ENVIRONMENT
+        )
 
         # Replace placeholders in the template
         args = {key: value for key, value in replacements.items()}

--- a/app/services/tool/templates/lambda_function.py.template
+++ b/app/services/tool/templates/lambda_function.py.template
@@ -3,8 +3,10 @@ from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
 
 sentry_sdk.init(
     dsn="{sentry_dsn}",
+    environment="{sentry_environment}",
     integrations=[AwsLambdaIntegration()],
     traces_sample_rate=1.0,
+    profiles_sample_rate=1.0,
 )
 
 def load_value(data):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds configurable Sentry instrumentation across the API and Lambda templates.
> 
> - Enable conditional `sentry_sdk.init` with `environment`, `release`, `traces_sample_rate`, `profiles_sample_rate`, and `debug`; add `SentryAsgiMiddleware` to wrap the FastAPI app
> - Introduce new settings: `SENTRY_ENVIRONMENT`, `SENTRY_TRACES_SAMPLE_RATE`, `SENTRY_PROFILES_SAMPLE_RATE`, `SENTRY_DEBUG`, `SENTRY_RELEASE`; validator now allows `staging`
> - Update Lambda templates to include `environment` and `profiles_sample_rate` in Sentry setup; `Packager.build_lambda_function_file` injects `sentry_environment` (fallback to `ENVIRONMENT`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c91bde4e2c5965f6449e6514e0b47df5ca35cc50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->