### PR TITLE
refactor: change log class from standard to infrequent access weni-cli-backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.0] - 2026-03-31
+- feat: improve agent evaluation file definition
+
 ## [1.11.1] - 2026-03-31
 - feat: improve agent evaluation file definition
 

--- a/app/api/v1/routers/tests/test_tool_logs.py
+++ b/app/api/v1/routers/tests/test_tool_logs.py
@@ -17,7 +17,8 @@ TEST_AGENT_KEY = "test-agent"
 TEST_TOOL_KEY = "test-tool"
 TEST_PROJECT_UUID = str(uuid4())
 TEST_AUTH_TOKEN = "Bearer test-token"
-TEST_LOG_GROUP_ARN = "arn:aws:logs:us-east-1:123456789012:log-group:/aws/lambda/test-function:*"
+TEST_LOG_GROUP_ARN = "arn:aws:logs:us-east-1:123456789012:log-group:/aws/lambda/agents-central:*"
+TEST_LAMBDA_NAME = "test-tool-42"
 
 
 @pytest.fixture(scope="module")
@@ -72,7 +73,12 @@ class TestGetLogsEndpoint:
         # Mock NexusClient response
         mock_nexus_response = mocker.Mock()
         mock_nexus_response.status_code = status.HTTP_200_OK
-        mock_nexus_response.json.return_value = {"log_group": {"log_group_arn": TEST_LOG_GROUP_ARN}}
+        mock_nexus_response.json.return_value = {
+            "log_group": {
+                "log_group_arn": TEST_LOG_GROUP_ARN,
+                "lambda_name": TEST_LAMBDA_NAME,
+            }
+        }
         mock_nexus_client = mocker.patch("app.api.v1.routers.tool_logs.NexusClient").return_value
         mock_nexus_client.get_log_group.return_value = mock_nexus_response
 
@@ -99,6 +105,7 @@ class TestGetLogsEndpoint:
         mock_nexus_client.get_log_group.assert_called_once_with(TEST_AGENT_KEY, TEST_TOOL_KEY)
         mock_aws_client.get_function_logs.assert_called_once_with(
             TEST_LOG_GROUP_ARN,
+            TEST_LAMBDA_NAME,
             mocker.ANY,  # Check specific times if needed, requires parsing params
             mocker.ANY,
             None,  # default_query_params doesn't include pattern
@@ -118,7 +125,12 @@ class TestGetLogsEndpoint:
         # Mock NexusClient response (same as success case)
         mock_nexus_response = mocker.Mock()
         mock_nexus_response.status_code = status.HTTP_200_OK
-        mock_nexus_response.json.return_value = {"log_group": {"log_group_arn": TEST_LOG_GROUP_ARN}}
+        mock_nexus_response.json.return_value = {
+            "log_group": {
+                "log_group_arn": TEST_LOG_GROUP_ARN,
+                "lambda_name": TEST_LAMBDA_NAME,
+            }
+        }
         mock_nexus_client = mocker.patch("app.api.v1.routers.tool_logs.NexusClient").return_value
         mock_nexus_client.get_log_group.return_value = mock_nexus_response
 
@@ -200,6 +212,67 @@ class TestGetLogsEndpoint:
         # Verify AWS client was NOT called
         mock_aws_client.get_function_logs.assert_not_called()
 
+    def test_get_logs_falls_back_to_tool_name_when_lambda_name_missing(  # noqa: PLR0913
+        self,
+        client: TestClient,
+        api_path: str,
+        common_headers: dict[str, str],
+        default_query_params: dict[str, Any],
+        mocker: MockerFixture,
+        mock_auth_middleware: None,
+    ) -> None:
+        """Backward-compat: older nexus only returns `tool_name`, which equals the lambda name."""
+        mock_nexus_response = mocker.Mock()
+        mock_nexus_response.status_code = status.HTTP_200_OK
+        mock_nexus_response.json.return_value = {
+            "log_group": {
+                "log_group_arn": TEST_LOG_GROUP_ARN,
+                "tool_name": TEST_LAMBDA_NAME,
+            }
+        }
+        mock_nexus_client = mocker.patch("app.api.v1.routers.tool_logs.NexusClient").return_value
+        mock_nexus_client.get_log_group.return_value = mock_nexus_response
+
+        mock_aws_client = mocker.patch("app.api.v1.routers.tool_logs.AWSLogsClient").return_value
+        mock_aws_client.get_function_logs = mocker.AsyncMock(return_value=([], None))
+
+        response = client.get(api_path, params=default_query_params, headers=common_headers)
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_aws_client.get_function_logs.assert_called_once_with(
+            TEST_LOG_GROUP_ARN,
+            TEST_LAMBDA_NAME,
+            mocker.ANY,
+            mocker.ANY,
+            None,
+            None,
+        )
+
+    def test_get_logs_nexus_response_missing_lambda_name(  # noqa: PLR0913
+        self,
+        client: TestClient,
+        api_path: str,
+        common_headers: dict[str, str],
+        default_query_params: dict[str, Any],
+        mocker: MockerFixture,
+        mock_auth_middleware: None,
+    ) -> None:
+        """Fail closed when neither `lambda_name` nor `tool_name` is provided."""
+        mock_nexus_response = mocker.Mock()
+        mock_nexus_response.status_code = status.HTTP_200_OK
+        mock_nexus_response.json.return_value = {
+            "log_group": {"log_group_arn": TEST_LOG_GROUP_ARN}
+        }
+        mock_nexus_client = mocker.patch("app.api.v1.routers.tool_logs.NexusClient").return_value
+        mock_nexus_client.get_log_group.return_value = mock_nexus_response
+
+        mock_aws_client = mocker.patch("app.api.v1.routers.tool_logs.AWSLogsClient").return_value
+
+        response = client.get(api_path, params=default_query_params, headers=common_headers)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert "Lambda name not found" in response.json()["message"]
+        mock_aws_client.get_function_logs.assert_not_called()
 
     def test_get_logs_aws_client_raises_exception(  # noqa: PLR0913
         self,
@@ -214,7 +287,12 @@ class TestGetLogsEndpoint:
         # Mock NexusClient response (success)
         mock_nexus_response = mocker.Mock()
         mock_nexus_response.status_code = status.HTTP_200_OK
-        mock_nexus_response.json.return_value = {"log_group": {"log_group_arn": TEST_LOG_GROUP_ARN}}
+        mock_nexus_response.json.return_value = {
+            "log_group": {
+                "log_group_arn": TEST_LOG_GROUP_ARN,
+                "lambda_name": TEST_LAMBDA_NAME,
+            }
+        }
         mock_nexus_client = mocker.patch("app.api.v1.routers.tool_logs.NexusClient").return_value
         mock_nexus_client.get_log_group.return_value = mock_nexus_response
 
@@ -243,7 +321,12 @@ class TestGetLogsEndpoint:
         # Mock NexusClient response
         mock_nexus_response = mocker.Mock()
         mock_nexus_response.status_code = status.HTTP_200_OK
-        mock_nexus_response.json.return_value = {"log_group": {"log_group_arn": TEST_LOG_GROUP_ARN}}
+        mock_nexus_response.json.return_value = {
+            "log_group": {
+                "log_group_arn": TEST_LOG_GROUP_ARN,
+                "lambda_name": TEST_LAMBDA_NAME,
+            }
+        }
         mock_nexus_client = mocker.patch("app.api.v1.routers.tool_logs.NexusClient").return_value
         mock_nexus_client.get_log_group.return_value = mock_nexus_response
 
@@ -275,8 +358,9 @@ class TestGetLogsEndpoint:
         # Verify mocks were called with pattern and token
         mock_aws_client.get_function_logs.assert_called_once_with(
             TEST_LOG_GROUP_ARN,
+            TEST_LAMBDA_NAME,
             mocker.ANY,
             mocker.ANY,
-            test_pattern, # Check pattern was passed
-            test_token,   # Check token was passed
+            test_pattern,  # Check pattern was passed
+            test_token,    # Check token was passed
         )

--- a/app/api/v1/routers/tool_logs.py
+++ b/app/api/v1/routers/tool_logs.py
@@ -38,7 +38,8 @@ async def get_logs(
     log_group_data = log_group.json()
 
     try:
-        log_group_arn = log_group_data["log_group"]["log_group_arn"]
+        log_group_payload = log_group_data["log_group"]
+        log_group_arn = log_group_payload["log_group_arn"]
     except Exception as e:
         logger.error(f"Error getting log group ARN: {e}")
         return JSONResponse(
@@ -46,9 +47,19 @@ async def get_logs(
             content={"status": "error", "message": "Log group not found in Nexus response"},
         )
 
+    # Newer nexus responses include `lambda_name` explicitly; fall back to
+    # `tool_name`, which historically held the same value.
+    lambda_name = log_group_payload.get("lambda_name") or log_group_payload.get("tool_name")
+    if not lambda_name:
+        logger.error("Nexus log-group response missing lambda_name/tool_name")
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content={"status": "error", "message": "Lambda name not found in Nexus response"},
+        )
+
     logs_client = AWSLogsClient()
     logs, next_token = await logs_client.get_function_logs(
-        log_group_arn, data.start_time, data.end_time, data.pattern, data.next_token
+        log_group_arn, lambda_name, data.start_time, data.end_time, data.pattern, data.next_token
     )
 
     return JSONResponse(

--- a/app/clients/aws/logs_client.py
+++ b/app/clients/aws/logs_client.py
@@ -1,4 +1,9 @@
+import asyncio
+import base64
+import json
 import logging
+import re
+import time
 from datetime import UTC, datetime
 from typing import Any
 
@@ -9,81 +14,218 @@ from app.core.config import settings
 logger = logging.getLogger(__name__)
 
 
+# Insights query statuses that indicate the query has finished (with or without success)
+_INSIGHTS_TERMINAL_STATUSES: frozenset[str] = frozenset({"Complete", "Failed", "Cancelled", "Timeout"})
+
+# Boilerplate emitted by the Lambda runtime that should never reach the user.
+# Each item is matched with `filter @message not like /^.../` in Logs Insights QL.
+_BOILERPLATE_PREFIXES: tuple[str, ...] = (
+    "START RequestId",
+    "END RequestId",
+    "REPORT RequestId",
+    "INIT_START Runtime Version",
+)
+
+
 class AWSLogsClient:
+    """Client for reading Lambda logs through CloudWatch Logs Insights.
+
+    The agents Lambdas now write to a single centralized log group (referenced
+    by `AWS_LAMBDA_LOG_GROUP` on nexus-ai). To return only the events of a
+    specific tool, queries filter on `@logStream`, which the AWS Lambda runtime
+    automatically names as `YYYY/MM/DD/<lambda_name>[<version>][<exec_env_id>]`
+    when a custom log group is used. This client is also compatible with legacy
+    per-tool log groups (Standard class) that haven't been migrated yet, since
+    the Insights query works on both classes.
+    """
+
     def __init__(self) -> None:
         self.client = boto3.client("logs", region_name=settings.AWS_REGION_NAME)
 
-    # Convert a datetime to milliseconds
-    # preserving the timezone or using UTC+0 if no timezone is present
-    def __format_time(self, time: datetime) -> int:
-        if time.tzinfo:
-            return int(time.astimezone(UTC).timestamp() * 1000)
-        else:
-            return int(time.replace(tzinfo=UTC).timestamp() * 1000)
+    @staticmethod
+    def _format_time_ms(time_value: datetime) -> int:
+        """Convert a datetime to epoch milliseconds (UTC)."""
+        if time_value.tzinfo:
+            return int(time_value.astimezone(UTC).timestamp() * 1000)
+        return int(time_value.replace(tzinfo=UTC).timestamp() * 1000)
 
-    async def get_function_logs(
+    @staticmethod
+    def _encode_cursor(start_time_ms: int) -> str:
+        """Pack the next page anchor (epoch ms) into an opaque, URL-safe token."""
+        payload = json.dumps({"start_ms": start_time_ms}, separators=(",", ":"))
+        return base64.urlsafe_b64encode(payload.encode("utf-8")).decode("ascii")
+
+    @staticmethod
+    def _decode_cursor(cursor: str) -> int | None:
+        """Unpack a previously emitted cursor. Returns None if invalid."""
+        try:
+            decoded = base64.urlsafe_b64decode(cursor.encode("ascii")).decode("utf-8")
+            payload = json.loads(decoded)
+            value = payload.get("start_ms")
+            return int(value) if value is not None else None
+        except (ValueError, TypeError, json.JSONDecodeError):
+            logger.warning("Discarding malformed Logs Insights cursor")
+            return None
+
+    @staticmethod
+    def _build_query(lambda_name: str, filter_pattern: str | None, limit: int) -> str:
+        """Compose the Logs Insights QL string for a single page.
+
+        The mandatory `filter @logStream like /.../` ensures multi-tenant
+        isolation when the log group is shared across many Lambdas. It
+        matches the `<lambda_name>[` segment so `tool` does not accidentally
+        match `tool_v2`.
+        """
+        escaped_lambda = re.escape(lambda_name)
+        parts: list[str] = [
+            "fields @timestamp, @message, @logStream",
+            f"filter @logStream like /\\/{escaped_lambda}\\[/",
+        ]
+        # The known runtime prefixes contain only letters, digits, spaces and
+        # underscores, so they're safe to embed verbatim in the regex.
+        for prefix in _BOILERPLATE_PREFIXES:
+            parts.append(f"filter @message not like /^{prefix}/")
+        if filter_pattern:
+            parts.append(f"filter @message like /{re.escape(filter_pattern)}/")
+        parts.append("sort @timestamp asc")
+        parts.append(f"limit {limit}")
+        return " | ".join(parts)
+
+    @staticmethod
+    def _row_to_field_map(row: list[dict[str, str]]) -> dict[str, str]:
+        return {field.get("field", ""): field.get("value", "") for field in row}
+
+    @classmethod
+    def _row_to_event(cls, row: list[dict[str, str]]) -> dict[str, Any] | None:
+        """Convert one Logs Insights row to the legacy event shape.
+
+        Mirrors what `filter_log_events` used to return so the API contract
+        with the CLI (`{timestamp: int_ms, message: str, logStreamName: str}`)
+        is preserved.
+        """
+        fields = cls._row_to_field_map(row)
+        timestamp_str = fields.get("@timestamp")
+        message = fields.get("@message")
+        if timestamp_str is None or message is None:
+            return None
+
+        # Insights returns timestamps as `YYYY-MM-DD HH:MM:SS.mmm` (UTC, naive)
+        try:
+            parsed = datetime.strptime(timestamp_str, "%Y-%m-%d %H:%M:%S.%f")
+        except ValueError:
+            try:
+                parsed = datetime.strptime(timestamp_str, "%Y-%m-%d %H:%M:%S")
+            except ValueError:
+                logger.warning("Skipping Insights row with unexpected timestamp format")
+                return None
+        timestamp_ms = int(parsed.replace(tzinfo=UTC).timestamp() * 1000)
+
+        return {
+            "timestamp": timestamp_ms,
+            "message": message,
+            "logStreamName": fields.get("@logStream", ""),
+        }
+
+    async def _wait_for_query(self, query_id: str) -> dict[str, Any]:
+        """Poll Logs Insights until the query reaches a terminal status."""
+        deadline = time.monotonic() + settings.AWS_LOGS_INSIGHTS_MAX_WAIT_SECONDS
+        while True:
+            await asyncio.sleep(settings.AWS_LOGS_INSIGHTS_POLL_INTERVAL_SECONDS)
+            response: dict[str, Any] = self.client.get_query_results(queryId=query_id)
+            status = response.get("status", "")
+            if status in _INSIGHTS_TERMINAL_STATUSES:
+                return response
+            if time.monotonic() > deadline:
+                try:
+                    self.client.stop_query(queryId=query_id)
+                except Exception:  # noqa: BLE001 — best effort
+                    logger.warning("Failed to stop Logs Insights query after timeout", exc_info=True)
+                raise TimeoutError(
+                    f"Logs Insights query {query_id} timed out after "
+                    f"{settings.AWS_LOGS_INSIGHTS_MAX_WAIT_SECONDS}s"
+                )
+
+    async def get_function_logs(  # noqa: PLR0913
         self,
         log_group_arn: str,
+        lambda_name: str,
         start_time: datetime | None,
         end_time: datetime | None,
         filter_pattern: str | None,
         next_token: str | None = None,
     ) -> tuple[list[dict[str, Any]], str | None]:
-        """
-        Get the logs for a lambda function
+        """Fetch a page of logs for a single Lambda from a (possibly shared) log group.
 
         Args:
-            log_group_name: The name of the log group to get the logs for
-            start_time: The start time of the logs to get
-            end_time: The end time of the logs to get
+            log_group_arn: ARN of the log group to query (centralized or legacy).
+            lambda_name: Function name used to filter `@logStream` and isolate
+                events of a single Lambda inside the shared log group.
+            start_time: Inclusive lower bound for the log window.
+            end_time: Inclusive upper bound for the log window. Defaults to now.
+            filter_pattern: Optional case-sensitive substring to match in `@message`.
+            next_token: Opaque cursor returned by a previous call.
 
         Returns:
-            A list of logs sorted by timestamp
-            A next token if there are more logs to get
+            Tuple of (events sorted ascending by timestamp, next_token or None).
         """
+        if not lambda_name:
+            raise ValueError("lambda_name is required for log isolation")
 
-        # Convert timestamps to milliseconds
-        start_time_ms = self.__format_time(start_time) if start_time else 0
-        end_time_ms = (
-            self.__format_time(end_time)
-            if end_time
-            else self.__format_time(datetime.now(UTC))
-        )
+        end_time_ms = self._format_time_ms(end_time) if end_time else self._format_time_ms(datetime.now(UTC))
+        if next_token:
+            cursor_ms = self._decode_cursor(next_token)
+            if cursor_ms is not None:
+                start_time_ms = cursor_ms
+            else:
+                start_time_ms = self._format_time_ms(start_time) if start_time else 0
+        else:
+            start_time_ms = self._format_time_ms(start_time) if start_time else 0
+
+        if start_time_ms >= end_time_ms:
+            return [], None
+
+        page_limit = settings.AWS_LOGS_INSIGHTS_PAGE_LIMIT
+        query_string = self._build_query(lambda_name, filter_pattern, page_limit)
 
         try:
-            current_token = next_token  # Use a different variable for the loop
-            while True:
-
-                exclude_pattern = '-"START RequestId" -"END RequestId" -"REPORT RequestId" -"INIT_START Runtime Version"'  # noqa: E501
-                final_filter_pattern = f'"{filter_pattern}" {exclude_pattern}' if filter_pattern else exclude_pattern
-
-                kwargs = {
-                    "logGroupIdentifier": log_group_arn,
-                    "startTime": start_time_ms,
-                    "endTime": end_time_ms,
-                    "limit": 1000,
-                    "filterPattern": final_filter_pattern,
-                }
-                if current_token:
-                    kwargs["nextToken"] = current_token
-
-                response = self.client.filter_log_events(**kwargs)
-                response_token = response.get("nextToken")
-                events = response.get("events", [])
-
-                # If we found events after filtering, return them and the next token
-                if events:
-                    return sorted(events, key=lambda x: x["timestamp"]), response_token
-
-                # If no events after filtering, but there are more pages, continue to the next page
-                if not events and response_token:
-                    current_token = response_token
-                    continue
-
-                # If no events after filtering and no more pages, return empty
-                if not events and not response_token:
-                    return [], None
-
+            start_response = self.client.start_query(
+                logGroupIdentifiers=[log_group_arn],
+                startTime=start_time_ms // 1000,
+                endTime=max(end_time_ms // 1000, 1),
+                queryString=query_string,
+                limit=page_limit,
+            )
         except Exception as e:
-            logger.error(f"Error getting logs for log group {log_group_arn}: {str(e)}")
-            raise e
+            logger.error(f"Error starting Logs Insights query for {log_group_arn}: {str(e)}")
+            raise
+
+        query_id = start_response["queryId"]
+
+        try:
+            result = await self._wait_for_query(query_id)
+        except Exception as e:
+            logger.error(f"Error reading logs from {log_group_arn}: {str(e)}")
+            raise
+
+        status = result.get("status", "")
+        if status != "Complete":
+            raise RuntimeError(f"Logs Insights query {query_id} ended with status {status}")
+
+        rows = result.get("results", []) or []
+        events: list[dict[str, Any]] = []
+        for row in rows:
+            event = self._row_to_event(row)
+            if event is not None:
+                events.append(event)
+
+        events.sort(key=lambda evt: evt["timestamp"])
+
+        # Pagination: if we filled the page, advance the start cursor past the
+        # last event returned. We use `+1ms` to avoid re-emitting the same
+        # event; this can drop sibling events sharing the exact same
+        # millisecond, which is acceptable for Lambda log volumes.
+        next_cursor: str | None = None
+        if len(events) >= page_limit:
+            next_cursor = self._encode_cursor(events[-1]["timestamp"] + 1)
+
+        return events, next_cursor

--- a/app/clients/aws/tests/test_logs_client.py
+++ b/app/clients/aws/tests/test_logs_client.py
@@ -1,3 +1,4 @@
+import re
 from datetime import UTC, datetime
 from typing import Any
 
@@ -9,132 +10,375 @@ from app.core.config import settings
 
 # Constants for status codes and expected response values
 HTTP_STATUS_OK = 200
-EXPECTED_CALL_COUNT_ZERO = 0
-EXPECTED_CALL_COUNT_ONE = 1
-EXPECTED_CALL_COUNT_TWO = 2
 
 # Constants for test data
 TEST_FUNCTION_NAME = "test-function"
+TEST_LAMBDA_NAME = "get_address-42"
 TEST_LOG_GROUP_NAME = settings.AGENT_LOG_GROUP
 TEST_START_TIME = 1609459200  # 2021-01-01T00:00:00Z in seconds
-TEST_START_TIME_MS = TEST_START_TIME * 1000  # 2021-01-01T00:00:00Z in milliseconds
+TEST_START_TIME_MS = TEST_START_TIME * 1000
 TEST_START_TIME_DATETIME = datetime.fromtimestamp(TEST_START_TIME, UTC)
 TEST_END_TIME = 1609459260  # 2021-01-01T00:01:00Z in seconds
-TEST_END_TIME_MS = TEST_END_TIME * 1000  # 2021-01-01T00:01:00Z in milliseconds
-TEST_END_TIME_DATETIME = datetime.fromtimestamp(TEST_END_TIME, UTC) 
-TEST_LOG_GROUP_ARN = "log-group-arn"
-MAX_RETRIES = 5
-RETRY_DELAY = 5  # seconds
+TEST_END_TIME_MS = TEST_END_TIME * 1000
+TEST_END_TIME_DATETIME = datetime.fromtimestamp(TEST_END_TIME, UTC)
+TEST_LOG_GROUP_ARN = "arn:aws:logs:us-east-1:123456789012:log-group:/aws/lambda/agents-central:*"
+TEST_QUERY_ID = "query-id-1234"
 MOCK_REQUEST_ID = "1234567890"
 
+# Page limit used to assert pagination behavior — kept tiny so tests remain fast.
+TEST_PAGE_LIMIT = 2
+# Number of polling iterations expected before the Insights query reaches Complete.
+EXPECTED_POLL_CALLS_UNTIL_COMPLETE = 3
+# Arbitrary fixed epoch-ms value for cursor round-trip assertions.
+SAMPLE_CURSOR_TIMESTAMP_MS = 1700000000000
 
-class MockResourceNotFoundError(Exception):
-    """Mock exception for ResourceNotFoundException from AWS boto3"""
 
-    pass
+def _insights_row(timestamp: str, message: str, log_stream: str = "2021/01/01/get_address-42[$LATEST][abc]") -> list:
+    """Build a Logs Insights result row in the boto3 shape."""
+    return [
+        {"field": "@timestamp", "value": timestamp},
+        {"field": "@message", "value": message},
+        {"field": "@logStream", "value": log_stream},
+    ]
 
 
 @pytest.fixture
 def mock_logs_client(mocker: MockerFixture) -> Any:
-    """
-    Create a mock for the logs client.
-    """
+    """Create a mock for the boto3 logs client."""
     mock_client = mocker.Mock()
-    # Configure the mock client to have the proper exceptions
-    mock_client.exceptions.ResourceNotFoundException = MockResourceNotFoundError
-
-    # Mock the boto3 module
+    mock_client.start_query.return_value = {"queryId": TEST_QUERY_ID}
     mocker.patch("boto3.client", return_value=mock_client)
-
     return mock_client
 
 
 @pytest.fixture
 def logs_client(mock_logs_client: Any) -> AWSLogsClient:
-    """
-    Return an AWSLogsClient instance with the mocked boto3 client.
-    """
     return AWSLogsClient()
 
 
-@pytest.fixture
-def test_log_events() -> list[dict[str, Any]]:
-    """Fixture for sample log events"""
-    return [
-        {"timestamp": 1609459300000, "message": "Log message 1", "logStreamName": "stream1"},
-        {"timestamp": 1609459400000, "message": "Log message 2", "logStreamName": "stream1"},
-        {"timestamp": 1609459200000, "message": "Log message 3", "logStreamName": "stream2"},
-    ]
-
-
-@pytest.fixture
-def mock_sleep(mocker: MockerFixture) -> Any:
-    """Mock asyncio.sleep to speed up tests"""
-    return mocker.patch("asyncio.sleep", return_value=None)
+@pytest.fixture(autouse=True)
+def fast_polling(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Avoid real sleeps during tests."""
+    monkeypatch.setattr(settings, "AWS_LOGS_INSIGHTS_POLL_INTERVAL_SECONDS", 0)
+    monkeypatch.setattr(settings, "AWS_LOGS_INSIGHTS_MAX_WAIT_SECONDS", 5)
 
 
 class TestAWSLogsClient:
     def test_init(self, mocker: MockerFixture) -> None:
-        """
-        Test that the client is initialized with the correct parameters.
-        """
-        # Setup
         mock_boto3 = mocker.patch("boto3.client")
-
-        # Execute
-        logs_client = AWSLogsClient()
-
-        # Assert
+        client = AWSLogsClient()
         mock_boto3.assert_called_once_with("logs", region_name=mocker.ANY)
-        assert logs_client.client is mock_boto3.return_value
+        assert client.client is mock_boto3.return_value
 
     @pytest.mark.asyncio
-    async def test_get_function_logs_success(
-        self, logs_client: AWSLogsClient, mock_logs_client: Any, test_log_events: list[dict[str, Any]]
+    async def test_get_function_logs_success_single_page(
+        self, logs_client: AWSLogsClient, mock_logs_client: Any
     ) -> None:
-        """
-        Test retrieving logs successfully on the first attempt.
-        """
-        # Setup
-        mock_logs_client.filter_log_events.return_value = {"events": test_log_events}
+        """Returns the events as `{timestamp, message, logStreamName}` and no next_token when below the page limit."""
+        mock_logs_client.get_query_results.return_value = {
+            "status": "Complete",
+            "results": [
+                _insights_row("2021-01-01 00:00:01.000", "first event"),
+                _insights_row("2021-01-01 00:00:03.500", "second event"),
+                _insights_row("2021-01-01 00:00:02.250", "third event"),
+            ],
+        }
 
-        # Execute
-        result, _ = await logs_client.get_function_logs(
+        events, next_token = await logs_client.get_function_logs(
             log_group_arn=TEST_LOG_GROUP_ARN,
+            lambda_name=TEST_LAMBDA_NAME,
             start_time=TEST_START_TIME_DATETIME,
             end_time=TEST_END_TIME_DATETIME,
-            filter_pattern=f'"{MOCK_REQUEST_ID}"',
+            filter_pattern=None,
         )
 
-        # Assert
-        mock_logs_client.filter_log_events.assert_called_once_with(
-            logGroupIdentifier=TEST_LOG_GROUP_ARN,
-            startTime=TEST_START_TIME_MS,
-            endTime=TEST_END_TIME_MS,
-            limit=1000,
-            filterPattern=f'""{MOCK_REQUEST_ID}"" -"START RequestId" -"END RequestId" -"REPORT RequestId" -"INIT_START Runtime Version"',  # noqa: E501
-        )
-        # The logs should be sorted by timestamp
-        assert result == sorted(test_log_events, key=lambda x: x["timestamp"])
-
+        assert next_token is None
+        assert [e["message"] for e in events] == ["first event", "third event", "second event"]
+        assert all(set(evt.keys()) == {"timestamp", "message", "logStreamName"} for evt in events)
 
     @pytest.mark.asyncio
-    async def test_get_function_logs_other_exception(self, logs_client: AWSLogsClient, mock_logs_client: Any) -> None:
-        """
-        Test when an unexpected exception occurs.
-        """
-        # Setup
-        test_exception = Exception("Test exception")
-        mock_logs_client.filter_log_events.side_effect = test_exception
+    async def test_get_function_logs_uses_logstream_filter(
+        self, logs_client: AWSLogsClient, mock_logs_client: Any
+    ) -> None:
+        """Critical multi-tenancy guard: the query MUST scope by @logStream."""
+        mock_logs_client.get_query_results.return_value = {"status": "Complete", "results": []}
 
-        # Execute and Assert
-        with pytest.raises(Exception) as exc_info:
+        await logs_client.get_function_logs(
+            log_group_arn=TEST_LOG_GROUP_ARN,
+            lambda_name=TEST_LAMBDA_NAME,
+            start_time=TEST_START_TIME_DATETIME,
+            end_time=TEST_END_TIME_DATETIME,
+            filter_pattern=None,
+        )
+
+        kwargs = mock_logs_client.start_query.call_args.kwargs
+        assert kwargs["logGroupIdentifiers"] == [TEST_LOG_GROUP_ARN]
+        assert "filter @logStream like" in kwargs["queryString"]
+        # Ensure we anchor the lambda name with the `[` opener of the version segment
+        # so `tool` does not match `tool_v2`. The lambda_name itself is regex-escaped.
+        escaped_name = re.escape(TEST_LAMBDA_NAME)
+        assert f"/\\/{escaped_name}\\[/" in kwargs["queryString"]
+        # Boilerplate exclusions are present
+        assert "filter @message not like /^START RequestId/" in kwargs["queryString"]
+        assert "filter @message not like /^END RequestId/" in kwargs["queryString"]
+        assert "filter @message not like /^REPORT RequestId/" in kwargs["queryString"]
+        assert "filter @message not like /^INIT_START Runtime Version/" in kwargs["queryString"]
+
+    @pytest.mark.asyncio
+    async def test_get_function_logs_includes_pattern_when_provided(
+        self, logs_client: AWSLogsClient, mock_logs_client: Any
+    ) -> None:
+        mock_logs_client.get_query_results.return_value = {"status": "Complete", "results": []}
+
+        await logs_client.get_function_logs(
+            log_group_arn=TEST_LOG_GROUP_ARN,
+            lambda_name=TEST_LAMBDA_NAME,
+            start_time=TEST_START_TIME_DATETIME,
+            end_time=TEST_END_TIME_DATETIME,
+            filter_pattern="ERROR",
+        )
+
+        query_string = mock_logs_client.start_query.call_args.kwargs["queryString"]
+        assert "filter @message like /ERROR/" in query_string
+
+    @pytest.mark.asyncio
+    async def test_get_function_logs_passes_seconds_to_insights(
+        self, logs_client: AWSLogsClient, mock_logs_client: Any
+    ) -> None:
+        """Logs Insights expects start/end as epoch seconds, unlike FilterLogEvents (ms)."""
+        mock_logs_client.get_query_results.return_value = {"status": "Complete", "results": []}
+
+        await logs_client.get_function_logs(
+            log_group_arn=TEST_LOG_GROUP_ARN,
+            lambda_name=TEST_LAMBDA_NAME,
+            start_time=TEST_START_TIME_DATETIME,
+            end_time=TEST_END_TIME_DATETIME,
+            filter_pattern=None,
+        )
+
+        kwargs = mock_logs_client.start_query.call_args.kwargs
+        assert kwargs["startTime"] == TEST_START_TIME
+        assert kwargs["endTime"] == TEST_END_TIME
+
+    @pytest.mark.asyncio
+    async def test_get_function_logs_emits_cursor_when_page_full(
+        self, logs_client: AWSLogsClient, mock_logs_client: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A full page (events == page_limit) emits an opaque next_token anchored past the last timestamp."""
+        monkeypatch.setattr(settings, "AWS_LOGS_INSIGHTS_PAGE_LIMIT", TEST_PAGE_LIMIT)
+        mock_logs_client.get_query_results.return_value = {
+            "status": "Complete",
+            "results": [
+                _insights_row("2021-01-01 00:00:01.000", "a"),
+                _insights_row("2021-01-01 00:00:02.000", "b"),
+            ],
+        }
+
+        events, next_token = await logs_client.get_function_logs(
+            log_group_arn=TEST_LOG_GROUP_ARN,
+            lambda_name=TEST_LAMBDA_NAME,
+            start_time=TEST_START_TIME_DATETIME,
+            end_time=TEST_END_TIME_DATETIME,
+            filter_pattern=None,
+        )
+
+        assert len(events) == TEST_PAGE_LIMIT
+        assert next_token is not None
+        decoded = AWSLogsClient._decode_cursor(next_token)
+        assert decoded == events[-1]["timestamp"] + 1
+
+    @pytest.mark.asyncio
+    async def test_get_function_logs_resumes_from_cursor(
+        self, logs_client: AWSLogsClient, mock_logs_client: Any
+    ) -> None:
+        """Calling with a previously emitted cursor advances the start of the window."""
+        cursor_ms = TEST_START_TIME_MS + 5_000
+        cursor = AWSLogsClient._encode_cursor(cursor_ms)
+        mock_logs_client.get_query_results.return_value = {"status": "Complete", "results": []}
+
+        await logs_client.get_function_logs(
+            log_group_arn=TEST_LOG_GROUP_ARN,
+            lambda_name=TEST_LAMBDA_NAME,
+            start_time=TEST_START_TIME_DATETIME,
+            end_time=TEST_END_TIME_DATETIME,
+            filter_pattern=None,
+            next_token=cursor,
+        )
+
+        kwargs = mock_logs_client.start_query.call_args.kwargs
+        assert kwargs["startTime"] == cursor_ms // 1000
+
+    @pytest.mark.asyncio
+    async def test_get_function_logs_ignores_malformed_cursor(
+        self, logs_client: AWSLogsClient, mock_logs_client: Any
+    ) -> None:
+        mock_logs_client.get_query_results.return_value = {"status": "Complete", "results": []}
+
+        await logs_client.get_function_logs(
+            log_group_arn=TEST_LOG_GROUP_ARN,
+            lambda_name=TEST_LAMBDA_NAME,
+            start_time=TEST_START_TIME_DATETIME,
+            end_time=TEST_END_TIME_DATETIME,
+            filter_pattern=None,
+            next_token="not-a-real-cursor",
+        )
+
+        # Falls back to the original start_time
+        kwargs = mock_logs_client.start_query.call_args.kwargs
+        assert kwargs["startTime"] == TEST_START_TIME
+
+    @pytest.mark.asyncio
+    async def test_get_function_logs_short_circuits_when_window_invalid(
+        self, logs_client: AWSLogsClient, mock_logs_client: Any
+    ) -> None:
+        """A cursor past the end_time should not query AWS at all."""
+        cursor = AWSLogsClient._encode_cursor(TEST_END_TIME_MS + 1)
+
+        events, next_token = await logs_client.get_function_logs(
+            log_group_arn=TEST_LOG_GROUP_ARN,
+            lambda_name=TEST_LAMBDA_NAME,
+            start_time=TEST_START_TIME_DATETIME,
+            end_time=TEST_END_TIME_DATETIME,
+            filter_pattern=None,
+            next_token=cursor,
+        )
+
+        assert events == []
+        assert next_token is None
+        mock_logs_client.start_query.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_function_logs_polls_until_complete(
+        self, logs_client: AWSLogsClient, mock_logs_client: Any
+    ) -> None:
+        mock_logs_client.get_query_results.side_effect = [
+            {"status": "Running", "results": []},
+            {"status": "Scheduled", "results": []},
+            {
+                "status": "Complete",
+                "results": [_insights_row("2021-01-01 00:00:01.000", "ok")],
+            },
+        ]
+
+        events, _ = await logs_client.get_function_logs(
+            log_group_arn=TEST_LOG_GROUP_ARN,
+            lambda_name=TEST_LAMBDA_NAME,
+            start_time=TEST_START_TIME_DATETIME,
+            end_time=TEST_END_TIME_DATETIME,
+            filter_pattern=None,
+        )
+
+        assert [e["message"] for e in events] == ["ok"]
+        assert mock_logs_client.get_query_results.call_count == EXPECTED_POLL_CALLS_UNTIL_COMPLETE
+
+    @pytest.mark.asyncio
+    async def test_get_function_logs_raises_on_non_complete_terminal_status(
+        self, logs_client: AWSLogsClient, mock_logs_client: Any
+    ) -> None:
+        mock_logs_client.get_query_results.return_value = {"status": "Failed", "results": []}
+
+        with pytest.raises(RuntimeError) as exc_info:
             await logs_client.get_function_logs(
                 log_group_arn=TEST_LOG_GROUP_ARN,
+                lambda_name=TEST_LAMBDA_NAME,
                 start_time=TEST_START_TIME_DATETIME,
                 end_time=TEST_END_TIME_DATETIME,
-                filter_pattern=f'{MOCK_REQUEST_ID}',
+                filter_pattern=None,
             )
 
-        assert exc_info.value is test_exception
-        mock_logs_client.filter_log_events.assert_called_once()
+        assert "Failed" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_get_function_logs_times_out_and_stops_query(
+        self,
+        logs_client: AWSLogsClient,
+        mock_logs_client: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(settings, "AWS_LOGS_INSIGHTS_MAX_WAIT_SECONDS", 0)
+        mock_logs_client.get_query_results.return_value = {"status": "Running", "results": []}
+
+        with pytest.raises(TimeoutError):
+            await logs_client.get_function_logs(
+                log_group_arn=TEST_LOG_GROUP_ARN,
+                lambda_name=TEST_LAMBDA_NAME,
+                start_time=TEST_START_TIME_DATETIME,
+                end_time=TEST_END_TIME_DATETIME,
+                filter_pattern=None,
+            )
+
+        mock_logs_client.stop_query.assert_called_once_with(queryId=TEST_QUERY_ID)
+
+    @pytest.mark.asyncio
+    async def test_get_function_logs_propagates_start_query_errors(
+        self, logs_client: AWSLogsClient, mock_logs_client: Any
+    ) -> None:
+        mock_logs_client.start_query.side_effect = RuntimeError("AWS Client Error")
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await logs_client.get_function_logs(
+                log_group_arn=TEST_LOG_GROUP_ARN,
+                lambda_name=TEST_LAMBDA_NAME,
+                start_time=TEST_START_TIME_DATETIME,
+                end_time=TEST_END_TIME_DATETIME,
+                filter_pattern=None,
+            )
+
+        assert "AWS Client Error" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_get_function_logs_requires_lambda_name(self, logs_client: AWSLogsClient) -> None:
+        with pytest.raises(ValueError):
+            await logs_client.get_function_logs(
+                log_group_arn=TEST_LOG_GROUP_ARN,
+                lambda_name="",
+                start_time=TEST_START_TIME_DATETIME,
+                end_time=TEST_END_TIME_DATETIME,
+                filter_pattern=None,
+            )
+
+    @pytest.mark.asyncio
+    async def test_get_function_logs_skips_rows_with_invalid_timestamp(
+        self, logs_client: AWSLogsClient, mock_logs_client: Any
+    ) -> None:
+        mock_logs_client.get_query_results.return_value = {
+            "status": "Complete",
+            "results": [
+                _insights_row("not-a-timestamp", "should be skipped"),
+                _insights_row("2021-01-01 00:00:01.000", "ok"),
+            ],
+        }
+
+        events, _ = await logs_client.get_function_logs(
+            log_group_arn=TEST_LOG_GROUP_ARN,
+            lambda_name=TEST_LAMBDA_NAME,
+            start_time=TEST_START_TIME_DATETIME,
+            end_time=TEST_END_TIME_DATETIME,
+            filter_pattern=None,
+        )
+
+        assert [e["message"] for e in events] == ["ok"]
+
+    @pytest.mark.asyncio
+    async def test_get_function_logs_defaults_end_time_to_now(
+        self, logs_client: AWSLogsClient, mock_logs_client: Any
+    ) -> None:
+        mock_logs_client.get_query_results.return_value = {"status": "Complete", "results": []}
+
+        await logs_client.get_function_logs(
+            log_group_arn=TEST_LOG_GROUP_ARN,
+            lambda_name=TEST_LAMBDA_NAME,
+            start_time=TEST_START_TIME_DATETIME,
+            end_time=None,
+            filter_pattern=None,
+        )
+
+        kwargs = mock_logs_client.start_query.call_args.kwargs
+        assert kwargs["endTime"] >= TEST_START_TIME
+
+    def test_cursor_round_trip(self) -> None:
+        token = AWSLogsClient._encode_cursor(SAMPLE_CURSOR_TIMESTAMP_MS)
+        assert AWSLogsClient._decode_cursor(token) == SAMPLE_CURSOR_TIMESTAMP_MS
+
+    def test_decode_cursor_invalid_returns_none(self) -> None:
+        assert AWSLogsClient._decode_cursor("abc!!!") is None

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -48,6 +48,12 @@ class Settings(BaseSettings):
     AGENT_LOG_GROUP: str = ""
     AWS_REGION_NAME: str = "us-east-1"
 
+    # CloudWatch Logs Insights polling (used when reading logs from
+    # the centralized log group via StartQuery / GetQueryResults)
+    AWS_LOGS_INSIGHTS_POLL_INTERVAL_SECONDS: float = 0.5
+    AWS_LOGS_INSIGHTS_MAX_WAIT_SECONDS: float = 30.0
+    AWS_LOGS_INSIGHTS_PAGE_LIMIT: int = 1000
+
     # Evaluation settings
     EVALUATION_DEFAULT_MODEL: str = "claude-haiku-4_5-global"
 


### PR DESCRIPTION
With the centralization of the lambda log group and the change of the log group class from `standard` to `infrequent access`, it was necessary to make some changes and adaptations to `weni-cli` and `weni-cli-backend`. This PR addresses these changes.