### PR TITLE
fix: return contact_urn on active lambda failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.13.0] - 2026-05-13
+- fix: return contact_urn on active lambda failures
+
 ## [1.12.0] - 2026-03-31
 - feat: improve agent evaluation file definition
 

--- a/app/services/agents/active/templates/lambda_function.py.template
+++ b/app/services/agents/active/templates/lambda_function.py.template
@@ -138,7 +138,7 @@ def lambda_handler(event, context):
                     status=ResponseStatus.GLOBAL_RULE_NOT_MATCHED,
                     template=None,
                     template_variables={},
-                    contact_urn=None,
+                    contact_urn=preprocess_result.urn,
                     traces={"preprocessor": preprocessor_traces},
                 ).to_dict()
     except Exception as error:
@@ -147,7 +147,7 @@ def lambda_handler(event, context):
             status=ResponseStatus.GLOBAL_RULE_FAILED,
             template=None,
             template_variables={},
-            contact_urn=None,
+            contact_urn=preprocess_result.urn,
             error=str(error),
             traces={"preprocessor": preprocessor_traces},
         ).to_dict()
@@ -165,7 +165,7 @@ def lambda_handler(event, context):
             status=ResponseStatus.CUSTOM_RULE_FAILED,
             template=None,
             template_variables={},
-            contact_urn=None,
+            contact_urn=preprocess_result.urn,
             error=str(error),
             traces={"preprocessor": preprocessor_traces, "project_rule": project_rule_traces},
         ).to_dict()
@@ -188,7 +188,7 @@ def lambda_handler(event, context):
             status=ResponseStatus.OFFICIAL_RULE_FAILED,
             template=None,
             template_variables={},
-            contact_urn=None,
+            contact_urn=preprocess_result.urn,
             error=str(error),
             traces={"preprocessor": preprocessor_traces, "project_rule": project_rule_traces, "official_rule": official_rule_traces},
         ).to_dict()
@@ -204,7 +204,7 @@ def lambda_handler(event, context):
             status=ResponseStatus.RULE_NOT_MATCHED,
             template=None,
             template_variables={},
-            contact_urn=None,
+            contact_urn=preprocess_result.urn,
             error={"message": "No template found"},
             traces=combined_traces,
         ).to_dict()


### PR DESCRIPTION
Even if a rule fails/is no matched after the preprocessing has completed, the contact urn should be returned in the lambda response