### PR TITLE
feat: improve target execution with web socket manipulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.13.1] - 2026-05-20
+- fix: fix race condition in evaluation web socket
+
 ## [1.13.0] - 2026-05-13
 - fix: return contact_urn on active lambda failures
 

--- a/app/api/v1/routers/evaluations.py
+++ b/app/api/v1/routers/evaluations.py
@@ -86,6 +86,13 @@ async def run_evaluation(
 
             target_config = data.target.copy()
             target_config.setdefault("type", "weni")
+            target_config.setdefault(
+                "connect_ws_first", settings.EVALUATION_TARGET_CONNECT_WS_FIRST
+            )
+            target_config.setdefault(
+                "accumulate_messages_window",
+                settings.EVALUATION_TARGET_ACCUMULATE_MESSAGES_WINDOW,
+            )
             target_config["weni_bearer_token"] = bearer_token
             target_config["weni_project_uuid"] = x_project_uuid
 

--- a/app/api/v1/routers/tests/test_evaluations.py
+++ b/app/api/v1/routers/tests/test_evaluations.py
@@ -318,3 +318,80 @@ class TestEvaluationEndpoint:
             assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
         finally:
             _rate_limiter.release(project_uuid)
+
+    def _patch_agenteval_for_target_config(self, mocker: MockerFixture) -> MagicMock:
+        """Patch the agenteval imports and return the TargetFactory class mock for inspection."""
+        mock_test = _make_mock_test()
+        mock_result = _make_mock_result(passed=True)
+        mock_test_suite = _make_mock_test_suite(mock_test)
+
+        mock_evaluator = MagicMock()
+        mock_evaluator.run.return_value = mock_result
+        mock_evaluator_factory = MagicMock()
+        mock_evaluator_factory.create.return_value = mock_evaluator
+        mock_target_factory = MagicMock()
+
+        mocker.patch(
+            "agenteval.evaluators.EvaluatorFactory",
+            return_value=mock_evaluator_factory,
+        )
+        target_factory_cls = mocker.patch(
+            "agenteval.targets.TargetFactory",
+            return_value=mock_target_factory,
+        )
+        mock_test_suite_cls = mocker.patch("agenteval.test.TestSuite")
+        mock_test_suite_cls.load.return_value = mock_test_suite
+        mocker.patch("agenteval.summary.create_markdown_summary")
+
+        return target_factory_cls
+
+    def test_evaluation_injects_default_target_ws_params(
+        self,
+        client: TestClient,
+        api_path: str,
+        auth_headers: dict[str, str],
+        evaluation_payload: dict[str, Any],
+        mocker: MockerFixture,
+        mock_auth_middleware: None,
+    ) -> None:
+        """The backend must inject WeniTarget WS params with the configured defaults."""
+        target_factory_cls = self._patch_agenteval_for_target_config(mocker)
+
+        response = client.post(api_path, json=evaluation_payload, headers=auth_headers)
+        assert response.status_code == status.HTTP_200_OK
+
+        target_factory_cls.assert_called_once()
+        config = target_factory_cls.call_args.kwargs["config"]
+        assert config["connect_ws_first"] is settings.EVALUATION_TARGET_CONNECT_WS_FIRST
+        assert config["accumulate_messages_window"] == settings.EVALUATION_TARGET_ACCUMULATE_MESSAGES_WINDOW
+
+    def test_evaluation_target_ws_params_can_be_overridden(
+        self,
+        client: TestClient,
+        api_path: str,
+        auth_headers: dict[str, str],
+        mocker: MockerFixture,
+        mock_auth_middleware: None,
+    ) -> None:
+        """Client-provided target values must override the backend defaults."""
+        target_factory_cls = self._patch_agenteval_for_target_config(mocker)
+
+        payload = {
+            "target": {
+                "connect_ws_first": False,
+                "accumulate_messages_window": 0.5,
+            },
+            "tests": {
+                "greeting": {
+                    "steps": ["Send a greeting message"],
+                    "expected_results": ["Agent responds with a greeting"],
+                }
+            },
+        }
+
+        response = client.post(api_path, json=payload, headers=auth_headers)
+        assert response.status_code == status.HTTP_200_OK
+
+        config = target_factory_cls.call_args.kwargs["config"]
+        assert config["connect_ws_first"] is False
+        assert config["accumulate_messages_window"] == 0.5

--- a/app/api/v1/routers/tests/test_evaluations.py
+++ b/app/api/v1/routers/tests/test_evaluations.py
@@ -15,6 +15,7 @@ from app.main import app
 
 TEST_TOKEN = "Bearer test-token"
 TEST_PROJECT_UUID = str(uuid4())
+CUSTOM_ACCUMULATE_MESSAGES_WINDOW = 0.5
 
 
 @pytest.fixture(scope="module")
@@ -379,7 +380,7 @@ class TestEvaluationEndpoint:
         payload = {
             "target": {
                 "connect_ws_first": False,
-                "accumulate_messages_window": 0.5,
+                "accumulate_messages_window": CUSTOM_ACCUMULATE_MESSAGES_WINDOW,
             },
             "tests": {
                 "greeting": {
@@ -394,4 +395,4 @@ class TestEvaluationEndpoint:
 
         config = target_factory_cls.call_args.kwargs["config"]
         assert config["connect_ws_first"] is False
-        assert config["accumulate_messages_window"] == 0.5
+        assert config["accumulate_messages_window"] == CUSTOM_ACCUMULATE_MESSAGES_WINDOW

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -56,6 +56,13 @@ class Settings(BaseSettings):
 
     # Evaluation settings
     EVALUATION_DEFAULT_MODEL: str = "claude-haiku-4_5-global"
+    # Open the WebSocket before sending the prompt to the agent. Closes the race window
+    # where early broadcasts could be missed by the WeniTarget listener.
+    EVALUATION_TARGET_CONNECT_WS_FIRST: bool = True
+    # Collect every broadcast received during a turn and wait this many seconds without
+    # a new message before returning the concatenated response. Required for agents that
+    # emit multiple messages per turn (e.g. text + catalog). 0 disables accumulation.
+    EVALUATION_TARGET_ACCUMULATE_MESSAGES_WINDOW: float = 2.0
 
     # JWT settings
     JWT_SECRET_KEY: str = ""

--- a/poetry.lock
+++ b/poetry.lock
@@ -2462,14 +2462,14 @@ test = ["pytest", "websockets"]
 
 [[package]]
 name = "weni-agenteval"
-version = "1.0.11"
+version = "1.1.0"
 description = "A generative AI-powered framework for testing virtual agents."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "weni_agenteval-1.0.11-py3-none-any.whl", hash = "sha256:2322cba160cf67f940cb80d443f5906d3abaa10a5c95fb8e7315f4106f152dd9"},
-    {file = "weni_agenteval-1.0.11.tar.gz", hash = "sha256:e51c24f88f9477b28009d181c6b3b4e2b1cfe4a1f110702de0875e7d56b9a397"},
+    {file = "weni_agenteval-1.1.0-py3-none-any.whl", hash = "sha256:1732ad0698c7fcedb37e61f0cca667de107e4b9a37fe33c0b530b2de30363b9f"},
+    {file = "weni_agenteval-1.1.0.tar.gz", hash = "sha256:aef8aa75eb74ea6b646d0463fd79211983aa935186b1dfaebaa59e8b3a6ff42b"},
 ]
 
 [package.dependencies]
@@ -2609,4 +2609,4 @@ dev = ["pytest", "setuptools"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "dadda78a6de71a0da37d9037389b874c4428e53911530c029da3c6140391ad77"
+content-hash = "b2be1f682f2577f4a834e085472587642ae5196d3fb3c2c547db9c41654a6800"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ httpx = "^0.28.1"
 sentry-sdk = {extras = ["fastapi"], version = "^2.22.0"}
 packaging = "^24.2"
 elastic-apm = "^6.25.0"
-weni-agenteval = "^1.0.11"
+weni-agenteval = "^1.1.0"
 PyJWT = "^2.8.0"
 cryptography = "^42.0.0"
 


### PR DESCRIPTION
## Contexto
Cliente reportou travamento e captura parcial de mensagens ao rodar `weni eval`
com 3+ steps em fluxos com catálogo. Causa-raiz identificada em dois bugs do
`WeniTarget` corrigidos em `weni-agenteval 1.1.0` (PR weni-agent-evaluation#XXX):
- Race entre POST e abertura do WebSocket.
- Captura apenas da primeira broadcast por turno.
A correção foi entregue como **opt-in** na lib para preservar compatibilidade
dos consumers externos. Este PR ativa os fixes para o nosso fluxo de avaliação.
## Mudanças
- `app/core/config.py`: dois settings novos com defaults seguros:
  - `EVALUATION_TARGET_CONNECT_WS_FIRST: bool = True`
  - `EVALUATION_TARGET_ACCUMULATE_MESSAGES_WINDOW: float = 2.0`
- `app/api/v1/routers/evaluations.py`: injeta os dois parâmetros no
  `target_config` via `setdefault`, respeitando override do cliente.
- `pyproject.toml`: `weni-agenteval = "^1.0.11"` → `"^1.1.0"`.
- Testes: 2 novos validando injeção dos defaults e override pelo payload.
## Compatibilidade
- Defaults via `setdefault` permitem ao cliente sobrescrever pelo payload
  (`target.connect_ws_first`, `target.accumulate_messages_window`).
- Sem mudança no schema do request — `target: dict[str, Any]` já aceitava
  campos arbitrários.
## Riscos
- O `accumulate_messages_window=2.0` adiciona ~2s a cada turno (espera pelo
  silêncio). Em um teste com 3 steps isso é +6s, irrisório frente ao timeout
  do target (480s).
## Sequência de deploy
1. Aguardar publicação de `weni-agenteval 1.1.0` no PyPI.
2. Regenerar `poetry.lock` (`poetry update weni-agenteval`).