### PR TITLE
feat: add elastic apm lambda instrumentation parameter per push in weni-cli-backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.2] - 2026-07-01
+- feat: propagate `apm_instrumentation` from CLI push to Nexus for passive agent tool lambdas
+
 ## [1.14.1] - 2026-06-15
 - feat: remove sentry sdk instrumentation from passive agent (tool) lambdas
 

--- a/app/api/v1/models/requests.py
+++ b/app/api/v1/models/requests.py
@@ -17,6 +17,7 @@ class ConfigureAgentsRequestModel(BaseRequestModel):
 
     # type can only be "active" or "passive"
     type: Literal["active", "passive"]
+    apm_instrumentation: Literal["enabled", "disabled"] | None = None
 
 
 class RunRequestModel(BaseRequestModel):

--- a/app/api/v1/routers/agents.py
+++ b/app/api/v1/routers/agents.py
@@ -12,6 +12,7 @@ from starlette.datastructures import UploadFile
 
 from app.api.v1.models.requests import ConfigureAgentsRequestModel
 from app.services.agents.active.configurator import ActiveAgentConfigurator
+from app.services.agents.configurators import AgentConfiguratorContext
 from app.services.agents.passive.configurator import PassiveAgentConfigurator
 
 router = APIRouter()
@@ -38,7 +39,12 @@ async def configure_agents(
         StreamingResponse: Streaming response for future result handling
     """
     request_id = str(uuid4())
-    logger.info(f"Processing agent configuration for project {data.project_uuid} - request_id: {request_id}")
+    logger.info(
+        "Processing agent configuration for project %s - request_id: %s (apm_instrumentation=%s)",
+        data.project_uuid,
+        request_id,
+        data.apm_instrumentation,
+    )
     logger.debug(f"Agent definition: {data.definition}")
 
     # Access the form data with files
@@ -59,13 +65,15 @@ async def configure_agents(
     }
 
     if configurator_cls := agent_configurators.get(data.type):
-        configurator_instance = configurator_cls(
-            str(data.project_uuid),
-            data.definition,
-            data.toolkit_version,
-            request_id,
-            authorization
+        context = AgentConfiguratorContext(
+            project_uuid=str(data.project_uuid),
+            definition=data.definition,
+            toolkit_version=data.toolkit_version,
+            request_id=request_id,
+            authorization=authorization,
+            apm_instrumentation=data.apm_instrumentation,
         )
+        configurator_instance = configurator_cls(context)
 
         return configurator_instance.configure_agents(agent_resources_folders_zips_entries)
 

--- a/app/clients/nexus_client.py
+++ b/app/clients/nexus_client.py
@@ -1,9 +1,12 @@
 import json
+import logging
 
 import requests
 from requests import Response
 
 from app.core.config import settings
+
+logger = logging.getLogger(__name__)
 
 
 class NexusClient:
@@ -16,13 +19,27 @@ class NexusClient:
         self.base_url = settings.NEXUS_BASE_URL
         self.project_uuid = project_uuid
 
-    def push_agents(self, agents_definition: dict, tool_files: dict) -> Response:
+    def push_agents(
+        self,
+        agents_definition: dict,
+        tool_files: dict,
+        apm_instrumentation: str | None = None,
+    ) -> Response:
         url = f"{self.base_url}/api/agents/push"
 
         data = {
             "project_uuid": self.project_uuid,
             "agents": json.dumps(agents_definition),
         }
+
+        if apm_instrumentation is not None:
+            data["apm_instrumentation"] = apm_instrumentation
+
+        logger.info(
+            "Pushing agents to Nexus for project %s (apm_instrumentation=%s)",
+            self.project_uuid,
+            apm_instrumentation,
+        )
 
         return requests.post(url, headers=self.headers, data=data, files=tool_files)
 

--- a/app/clients/tests/test_nexus_client.py
+++ b/app/clients/tests/test_nexus_client.py
@@ -115,6 +115,26 @@ class TestNexusClient:
         # Verify files were present in the request
         assert "tool-test-tool" in last_request.text
 
+    def test_push_agents_with_apm_instrumentation(
+        self,
+        requests_mock: requests_mock.Mocker,
+        nexus_client: NexusClient,
+        project_uuid: str,
+        agents_definition: dict,
+        tool_files: dict,
+    ) -> None:
+        """Test the push_agents method with APM instrumentation."""
+        expected_url = f"{settings.NEXUS_BASE_URL}/api/agents/push"
+        requests_mock.post(expected_url, json={"success": True}, status_code=status.HTTP_200_OK)
+
+        response = nexus_client.push_agents(agents_definition, tool_files, "enabled")
+
+        assert response.status_code == status.HTTP_200_OK
+        last_request = requests_mock.last_request
+        assert last_request is not None
+        assert "apm_instrumentation" in last_request.text
+        assert "enabled" in last_request.text
+
     def test_push_agents_error_response(  # noqa: PLR0913
         self,
         requests_mock: requests_mock.Mocker,

--- a/app/services/agents/active/configurator.py
+++ b/app/services/agents/active/configurator.py
@@ -20,11 +20,6 @@ PREPROCESSOR_OUTPUT_EXAMPLE_KEY = "preprocessor_example"
 
 
 class ActiveAgentConfigurator(AgentConfigurator):
-    def __init__(
-        self, project_uuid: str, definition: dict[str, Any], toolkit_version: str, request_id: str, authorization: str
-    ):
-        super().__init__(project_uuid, definition, toolkit_version, request_id, authorization)
-
     def configure_agents(self, agent_resources_entries: list[tuple[str, bytes]]) -> StreamingResponse:
         resource_count = len(agent_resources_entries)
 

--- a/app/services/agents/active/tests/test_active_configurator.py
+++ b/app/services/agents/active/tests/test_active_configurator.py
@@ -14,6 +14,7 @@ from app.services.agents.active.configurator import (
     ActiveAgentConfigurator,
 )
 from app.services.agents.active.models import ActiveAgentResourceModel, Resource, RuleResource
+from app.services.agents.configurators import AgentConfiguratorContext
 
 EXPECTED_SEND_RESPONSE_CALLS_SUCCESS = 2
 
@@ -75,7 +76,15 @@ def configurator(
     toolkit_version = "1.0.0"
     request_id = "test-request-id"
     authorization = "test-auth_token"
-    return ActiveAgentConfigurator(project_uuid, definition, toolkit_version, request_id, authorization)
+    return ActiveAgentConfigurator(
+        AgentConfiguratorContext(
+            project_uuid=project_uuid,
+            definition=definition,
+            toolkit_version=toolkit_version,
+            request_id=request_id,
+            authorization=authorization,
+        )
+    )
 
 
 @pytest.mark.asyncio

--- a/app/services/agents/configurators.py
+++ b/app/services/agents/configurators.py
@@ -1,24 +1,30 @@
 import logging
+from dataclasses import dataclass
 from typing import Any
 
 from fastapi.responses import StreamingResponse
 
 logger = logging.getLogger(__name__)
 
+
+@dataclass
+class AgentConfiguratorContext:
+    project_uuid: str
+    definition: dict[str, Any]
+    toolkit_version: str
+    request_id: str
+    authorization: str
+    apm_instrumentation: str | None = None
+
+
 class AgentConfigurator:
-    def __init__(
-        self,
-        project_uuid: str,
-        definition: dict[str, Any],
-        toolkit_version: str,
-        request_id: str,
-        authorization: str,
-    ):
-        self.project_uuid = project_uuid
-        self.definition = definition
-        self.toolkit_version = toolkit_version
-        self.request_id = request_id
-        self.authorization = authorization
+    def __init__(self, context: AgentConfiguratorContext):
+        self.project_uuid = context.project_uuid
+        self.definition = context.definition
+        self.toolkit_version = context.toolkit_version
+        self.request_id = context.request_id
+        self.authorization = context.authorization
+        self.apm_instrumentation = context.apm_instrumentation
 
     def configure_agents(self, agent_resources_entries: list[tuple[str, bytes]]) -> StreamingResponse:
         raise NotImplementedError("This method should be implemented by the subclass")

--- a/app/services/agents/passive/configurator.py
+++ b/app/services/agents/passive/configurator.py
@@ -14,11 +14,6 @@ logger = logging.getLogger(__name__)
 
 
 class PassiveAgentConfigurator(AgentConfigurator):
-    def __init__(
-        self, project_uuid: str, definition: dict[str, Any], toolkit_version: str, request_id: str, authorization: str
-    ):
-        super().__init__(project_uuid, definition, toolkit_version, request_id, authorization)
-
     def configure_agents(
         self,
         agent_resources_entries: list[tuple[str, bytes]],
@@ -149,7 +144,12 @@ class PassiveAgentConfigurator(AgentConfigurator):
             Tuple of (success, response)
         """
         try:
-            logger.info(f"Sending {len(tool_mapping)} processed tools to Nexus for project {self.project_uuid}")
+            logger.info(
+                "Sending %s processed tools to Nexus for project %s (apm_instrumentation=%s)",
+                len(tool_mapping),
+                self.project_uuid,
+                self.apm_instrumentation,
+            )
             nexus_client = NexusClient(self.authorization, self.project_uuid)
 
             # We need to change the entrypoint to the lambda function we've created
@@ -157,7 +157,7 @@ class PassiveAgentConfigurator(AgentConfigurator):
                 for tool in agent_data["tools"]:
                     tool["source"]["entrypoint"] = "lambda_function.lambda_handler"
 
-            response = nexus_client.push_agents(self.definition, tool_mapping)
+            response = nexus_client.push_agents(self.definition, tool_mapping, self.apm_instrumentation)
 
             if response.status_code != status.HTTP_200_OK:
                 raise Exception(f"Failed to push agents: {response.status_code} {response.text}")

--- a/app/services/agents/passive/tests/test_passive_configurator.py
+++ b/app/services/agents/passive/tests/test_passive_configurator.py
@@ -7,6 +7,7 @@ from fastapi.responses import StreamingResponse
 from pytest_mock import MockerFixture
 
 from app.core.response import CLIResponse
+from app.services.agents.configurators import AgentConfiguratorContext
 from app.services.agents.passive.configurator import PassiveAgentConfigurator
 
 NEXUS_UPLOAD_ERROR_PROGRESS = 0.9
@@ -76,7 +77,15 @@ def configurator(
     toolkit_version = "1.0.0"
     request_id = "test-request-id"
     authorization = "test-auth_token"
-    return PassiveAgentConfigurator(project_uuid, definition, toolkit_version, request_id, authorization)
+    return PassiveAgentConfigurator(
+        AgentConfiguratorContext(
+            project_uuid=project_uuid,
+            definition=definition,
+            toolkit_version=toolkit_version,
+            request_id=request_id,
+            authorization=authorization,
+        )
+    )
 
 
 # --- Test Cases for configure_agents ---
@@ -172,7 +181,7 @@ async def test_configure_agents_success(
     expected_definition = configurator.definition.copy()
     expected_definition["agents"]["agent1"]["tools"][0]["source"]["entrypoint"] = "lambda_function.lambda_handler"
     mock_nexus_client.return_value.push_agents.assert_called_once_with(
-       expected_definition, expected_tool_mapping
+       expected_definition, expected_tool_mapping, None
     )
 
     # Verify final message
@@ -376,7 +385,7 @@ async def test_configure_agents_empty_input(
         expected_definition["agents"]["agent1"]["tools"][0]["source"]["entrypoint"] = "lambda_function.lambda_handler"
 
     mock_nexus_client.return_value.push_agents.assert_called_once_with(
-        expected_definition, expected_tool_mapping
+        expected_definition, expected_tool_mapping, None
     )
 
 
@@ -419,10 +428,13 @@ def test_push_to_nexus_success(
     expected_definition["agents"]["agent1"]["tools"][0]["source"]["entrypoint"] = "lambda_function.lambda_handler"
 
     mock_nexus_client.return_value.push_agents.assert_called_once_with(
-        expected_definition, tool_mapping
+        expected_definition, tool_mapping, None
     )
     mock_logger.info.assert_any_call(
-        f"Sending {len(tool_mapping)} processed tools to Nexus for project {configurator.project_uuid}"
+        "Sending %s processed tools to Nexus for project %s (apm_instrumentation=%s)",
+        len(tool_mapping),
+        configurator.project_uuid,
+        configurator.apm_instrumentation,
     )
     mock_logger.info.assert_any_call(f"Successfully pushed agents to Nexus for project {configurator.project_uuid}")
 


### PR DESCRIPTION
Propagates the `apm_instrumentation` field from the CLI to Nexus on passive agent push.

- Optional field on `ConfigureAgentsRequestModel`
- `NexusClient.push_agents()` sends the parameter to /api/agents/push
- Refactored configurators to use AgentConfiguratorContext

Active agents are unaffected — the field is ignored in that flow.